### PR TITLE
Add: support dns (lookup) command

### DIFF
--- a/@types/node-dig-dns.d.ts
+++ b/@types/node-dig-dns.d.ts
@@ -11,7 +11,7 @@ declare module 'node-dig-dns' {
 		answer: SingleDnsQueryResult[];
 	};
 
-	export function dig(args: string[]): DnsQueryResult;
+	export function dig(args: string[]): Promise<DnsQueryResult>;
 
 	export default dig;
 }

--- a/@types/node-dig-dns.d.ts
+++ b/@types/node-dig-dns.d.ts
@@ -1,0 +1,17 @@
+declare module 'node-dig-dns' {
+	export type SingleDnsQueryResult = {
+		domain: string;
+		type: string;
+		ttl: number;
+		class: string;
+		value: string;
+	};
+
+	export type DnsQueryResult = {
+		answer: SingleDnsQueryResult[];
+	};
+
+	export function dig(args: string[]): DnsQueryResult;
+
+	export default dig;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "crypto-random-string": "^4.0.0",
+        "domain-info": "^0.1.2",
         "execa": "^6.1.0",
         "joi": "^17.6.0",
         "lodash": "^4.17.21",
@@ -501,6 +502,11 @@
       "integrity": "sha512-Pt8Bunl40PyFvIcQ5berMYXt0XT94hWI4+5J7Ojl/k9NU75zHJibHUt3oRjiloy4x1rPcX0UJyq+yBjkMmv8zQ==",
       "dev": true
     },
+    "node_modules/@types/tldjs": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/tldjs/-/tldjs-1.7.1.tgz",
+      "integrity": "sha1-BdPvPLbgPPOt8eSgQ8FHDPIOF5k="
+    },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -887,6 +893,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -919,6 +933,14 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/binaryheap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/binaryheap/-/binaryheap-0.0.3.tgz",
+      "integrity": "sha1-DWE2yE6fGlqQwLlxeMPgDfWYINY=",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -979,6 +1001,17 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "peer": true
+    },
+    "node_modules/buffercursor": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/buffercursor/-/buffercursor-0.0.12.tgz",
+      "integrity": "sha1-eKmn9DQ659ggqJmazIDeWR4lp3k=",
+      "dependencies": {
+        "verror": "^1.4.0"
+      },
+      "engines": {
+        "node": ">= 0.5.0"
+      }
     },
     "node_modules/builtin-modules": {
       "version": "3.2.0",
@@ -1308,6 +1341,11 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -1491,6 +1529,23 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/domain-info": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/domain-info/-/domain-info-0.1.2.tgz",
+      "integrity": "sha512-Rjva7t+L0RRnvFpTM6DNddjBx48CKMbzC75dcpAH5JBH+Lknfa1w/q/G5c0JwaH3HSI/Hf8/yCplzIC4JsXmIA==",
+      "dependencies": {
+        "@types/node": "^10.9.4",
+        "@types/tldjs": "^1.7.1",
+        "es6-promise": "^4.0.5",
+        "native-dns": "^0.7.0",
+        "tldjs": "^1.6.2"
+      }
+    },
+    "node_modules/domain-info/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.82",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.82.tgz",
@@ -1646,6 +1701,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -2355,6 +2415,14 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "engines": [
+        "node >=0.6.0"
+      ]
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3012,6 +3080,14 @@
       "dev": true,
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz",
+      "integrity": "sha1-qceMzBLckBDylqua7y9h9DLWnvo=",
+      "engines": {
+        "node": ">= 0.2.5"
       }
     },
     "node_modules/irregular-plurals": {
@@ -4051,6 +4127,43 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/native-dns": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/native-dns/-/native-dns-0.7.0.tgz",
+      "integrity": "sha1-30GGNvCPsp6Py37xQsgioViLpbc=",
+      "dependencies": {
+        "ipaddr.js": "~0.1.3",
+        "native-dns-cache": "~0.0.2",
+        "native-dns-packet": "~0.1.1"
+      },
+      "engines": {
+        "node": ">= 0.5.0"
+      }
+    },
+    "node_modules/native-dns-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/native-dns-cache/-/native-dns-cache-0.0.2.tgz",
+      "integrity": "sha1-zgmY9/32x5kJcKMxkGJLDpjulZs=",
+      "dependencies": {
+        "binaryheap": ">= 0.0.3",
+        "native-dns-packet": ">= 0.0.1"
+      },
+      "engines": {
+        "node": ">= 0.5.0"
+      }
+    },
+    "node_modules/native-dns-packet": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/native-dns-packet/-/native-dns-packet-0.1.1.tgz",
+      "integrity": "sha1-l9qQVwuEOKABlHAc4k0BH9PMEJo=",
+      "dependencies": {
+        "buffercursor": ">= 0.0.12",
+        "ipaddr.js": ">= 0.1.1"
+      },
+      "engines": {
+        "node": ">= 0.5.0"
       }
     },
     "node_modules/natural-compare": {
@@ -5490,6 +5603,23 @@
         "node": ">= 10"
       }
     },
+    "node_modules/tldjs": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-1.8.0.tgz",
+      "integrity": "sha1-ucFr1t41e1X/y+fVvkH2s8p24/o=",
+      "hasInstallScript": true,
+      "dependencies": {
+        "punycode": "^1.4.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/tldjs/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+    },
     "node_modules/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -5725,6 +5855,19 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/watchpack": {
@@ -6047,6 +6190,7 @@
     },
     "node_modules/xo/node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6059,6 +6203,7 @@
     },
     "node_modules/xo/node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6067,6 +6212,7 @@
     },
     "node_modules/xo/node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6079,11 +6225,13 @@
     },
     "node_modules/xo/node_modules/@types/json-schema": {
       "version": "7.0.9",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/xo/node_modules/@typescript-eslint/eslint-plugin": {
       "version": "5.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6116,6 +6264,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
       "version": "5.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6124,6 +6273,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/parser": {
       "version": "5.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6150,6 +6300,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/scope-manager": {
       "version": "5.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6166,6 +6317,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/type-utils": {
       "version": "5.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6191,6 +6343,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/types": {
       "version": "5.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6203,6 +6356,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/typescript-estree": {
       "version": "5.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6229,6 +6383,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
       "version": "11.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6248,6 +6403,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/ignore": {
       "version": "5.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6256,6 +6412,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6264,6 +6421,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/utils": {
       "version": "5.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6287,6 +6445,7 @@
     },
     "node_modules/xo/node_modules/@typescript-eslint/visitor-keys": {
       "version": "5.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6303,6 +6462,7 @@
     },
     "node_modules/xo/node_modules/array-union": {
       "version": "2.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6311,6 +6471,7 @@
     },
     "node_modules/xo/node_modules/braces": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6322,6 +6483,7 @@
     },
     "node_modules/xo/node_modules/debug": {
       "version": "4.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6338,11 +6500,13 @@
     },
     "node_modules/xo/node_modules/debug/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/xo/node_modules/dir-glob": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6354,6 +6518,7 @@
     },
     "node_modules/xo/node_modules/eslint-config-xo-typescript": {
       "version": "0.50.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6370,6 +6535,7 @@
     },
     "node_modules/xo/node_modules/eslint-scope": {
       "version": "5.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6382,6 +6548,7 @@
     },
     "node_modules/xo/node_modules/eslint-scope/node_modules/estraverse": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6390,6 +6557,7 @@
     },
     "node_modules/xo/node_modules/eslint-utils": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6407,6 +6575,7 @@
     },
     "node_modules/xo/node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -6415,6 +6584,7 @@
     },
     "node_modules/xo/node_modules/eslint-visitor-keys": {
       "version": "3.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -6423,6 +6593,7 @@
     },
     "node_modules/xo/node_modules/esrecurse": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -6434,6 +6605,7 @@
     },
     "node_modules/xo/node_modules/estraverse": {
       "version": "5.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6442,6 +6614,7 @@
     },
     "node_modules/xo/node_modules/fast-glob": {
       "version": "3.2.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6457,6 +6630,7 @@
     },
     "node_modules/xo/node_modules/fastq": {
       "version": "1.13.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6465,6 +6639,7 @@
     },
     "node_modules/xo/node_modules/fill-range": {
       "version": "7.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6492,11 +6667,13 @@
     },
     "node_modules/xo/node_modules/functional-red-black-tree": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/xo/node_modules/glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6508,6 +6685,7 @@
     },
     "node_modules/xo/node_modules/is-extglob": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6516,6 +6694,7 @@
     },
     "node_modules/xo/node_modules/is-glob": {
       "version": "4.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6527,6 +6706,7 @@
     },
     "node_modules/xo/node_modules/is-number": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6550,6 +6730,7 @@
     },
     "node_modules/xo/node_modules/lru-cache": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6561,6 +6742,7 @@
     },
     "node_modules/xo/node_modules/merge2": {
       "version": "1.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6569,6 +6751,7 @@
     },
     "node_modules/xo/node_modules/micromatch": {
       "version": "4.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6620,6 +6803,7 @@
     },
     "node_modules/xo/node_modules/path-type": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6628,6 +6812,7 @@
     },
     "node_modules/xo/node_modules/picomatch": {
       "version": "2.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6639,6 +6824,7 @@
     },
     "node_modules/xo/node_modules/queue-microtask": {
       "version": "1.2.3",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6658,6 +6844,7 @@
     },
     "node_modules/xo/node_modules/regexpp": {
       "version": "3.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6669,6 +6856,7 @@
     },
     "node_modules/xo/node_modules/reusify": {
       "version": "1.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6678,6 +6866,7 @@
     },
     "node_modules/xo/node_modules/run-parallel": {
       "version": "1.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6700,6 +6889,7 @@
     },
     "node_modules/xo/node_modules/semver": {
       "version": "7.3.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6714,6 +6904,7 @@
     },
     "node_modules/xo/node_modules/to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6725,11 +6916,13 @@
     },
     "node_modules/xo/node_modules/tslib": {
       "version": "1.14.1",
+      "dev": true,
       "inBundle": true,
       "license": "0BSD"
     },
     "node_modules/xo/node_modules/tsutils": {
       "version": "3.21.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6744,6 +6937,7 @@
     },
     "node_modules/xo/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -7286,6 +7480,11 @@
       "integrity": "sha512-Pt8Bunl40PyFvIcQ5berMYXt0XT94hWI4+5J7Ojl/k9NU75zHJibHUt3oRjiloy4x1rPcX0UJyq+yBjkMmv8zQ==",
       "dev": true
     },
+    "@types/tldjs": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@types/tldjs/-/tldjs-1.7.1.tgz",
+      "integrity": "sha1-BdPvPLbgPPOt8eSgQ8FHDPIOF5k="
+    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -7610,6 +7809,11 @@
       "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
       "dev": true
     },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -7637,6 +7841,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
+    },
+    "binaryheap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/binaryheap/-/binaryheap-0.0.3.tgz",
+      "integrity": "sha1-DWE2yE6fGlqQwLlxeMPgDfWYINY="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -7683,6 +7892,14 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "peer": true
+    },
+    "buffercursor": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/buffercursor/-/buffercursor-0.0.12.tgz",
+      "integrity": "sha1-eKmn9DQ659ggqJmazIDeWR4lp3k=",
+      "requires": {
+        "verror": "^1.4.0"
+      }
     },
     "builtin-modules": {
       "version": "3.2.0",
@@ -7948,6 +8165,11 @@
         }
       }
     },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
     "cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -8075,6 +8297,25 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
+      }
+    },
+    "domain-info": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/domain-info/-/domain-info-0.1.2.tgz",
+      "integrity": "sha512-Rjva7t+L0RRnvFpTM6DNddjBx48CKMbzC75dcpAH5JBH+Lknfa1w/q/G5c0JwaH3HSI/Hf8/yCplzIC4JsXmIA==",
+      "requires": {
+        "@types/node": "^10.9.4",
+        "@types/tldjs": "^1.7.1",
+        "es6-promise": "^4.0.5",
+        "native-dns": "^0.7.0",
+        "tldjs": "^1.6.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "10.17.60",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+        }
       }
     },
     "electron-to-chromium": {
@@ -8207,6 +8448,11 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -8732,6 +8978,11 @@
         "strip-final-newline": "^3.0.0"
       }
     },
+    "extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9215,6 +9466,11 @@
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
+    },
+    "ipaddr.js": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz",
+      "integrity": "sha1-qceMzBLckBDylqua7y9h9DLWnvo="
     },
     "irregular-plurals": {
       "version": "3.3.0",
@@ -9983,6 +10239,34 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
       "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
+    },
+    "native-dns": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/native-dns/-/native-dns-0.7.0.tgz",
+      "integrity": "sha1-30GGNvCPsp6Py37xQsgioViLpbc=",
+      "requires": {
+        "ipaddr.js": "~0.1.3",
+        "native-dns-cache": "~0.0.2",
+        "native-dns-packet": "~0.1.1"
+      }
+    },
+    "native-dns-cache": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/native-dns-cache/-/native-dns-cache-0.0.2.tgz",
+      "integrity": "sha1-zgmY9/32x5kJcKMxkGJLDpjulZs=",
+      "requires": {
+        "binaryheap": ">= 0.0.3",
+        "native-dns-packet": ">= 0.0.1"
+      }
+    },
+    "native-dns-packet": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/native-dns-packet/-/native-dns-packet-0.1.1.tgz",
+      "integrity": "sha1-l9qQVwuEOKABlHAc4k0BH9PMEJo=",
+      "requires": {
+        "buffercursor": ">= 0.0.12",
+        "ipaddr.js": ">= 0.1.1"
+      }
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -10998,6 +11282,21 @@
         "lodash": "^4.17.20"
       }
     },
+    "tldjs": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-1.8.0.tgz",
+      "integrity": "sha1-ucFr1t41e1X/y+fVvkH2s8p24/o=",
+      "requires": {
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
+      }
+    },
     "to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -11169,6 +11468,16 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
       }
     },
     "watchpack": {
@@ -11402,6 +11711,7 @@
         "@nodelib/fs.scandir": {
           "version": "2.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@nodelib/fs.stat": "2.0.5",
             "run-parallel": "^1.1.9"
@@ -11409,11 +11719,13 @@
         },
         "@nodelib/fs.stat": {
           "version": "2.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "@nodelib/fs.walk": {
           "version": "1.2.8",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@nodelib/fs.scandir": "2.1.5",
             "fastq": "^1.6.0"
@@ -11421,11 +11733,13 @@
         },
         "@types/json-schema": {
           "version": "7.0.9",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
           "version": "5.11.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@typescript-eslint/scope-manager": "5.11.0",
             "@typescript-eslint/type-utils": "5.11.0",
@@ -11440,13 +11754,15 @@
           "dependencies": {
             "ignore": {
               "version": "5.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "@typescript-eslint/parser": {
           "version": "5.11.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@typescript-eslint/scope-manager": "5.11.0",
             "@typescript-eslint/types": "5.11.0",
@@ -11457,6 +11773,7 @@
         "@typescript-eslint/scope-manager": {
           "version": "5.11.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.11.0",
             "@typescript-eslint/visitor-keys": "5.11.0"
@@ -11465,6 +11782,7 @@
         "@typescript-eslint/type-utils": {
           "version": "5.11.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@typescript-eslint/utils": "5.11.0",
             "debug": "^4.3.2",
@@ -11473,11 +11791,13 @@
         },
         "@typescript-eslint/types": {
           "version": "5.11.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "@typescript-eslint/typescript-estree": {
           "version": "5.11.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.11.0",
             "@typescript-eslint/visitor-keys": "5.11.0",
@@ -11491,6 +11811,7 @@
             "globby": {
               "version": "11.1.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -11502,17 +11823,20 @@
             },
             "ignore": {
               "version": "5.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "slash": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "@typescript-eslint/utils": {
           "version": "5.11.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@types/json-schema": "^7.0.9",
             "@typescript-eslint/scope-manager": "5.11.0",
@@ -11525,6 +11849,7 @@
         "@typescript-eslint/visitor-keys": {
           "version": "5.11.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@typescript-eslint/types": "5.11.0",
             "eslint-visitor-keys": "^3.0.0"
@@ -11532,11 +11857,13 @@
         },
         "array-union": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "braces": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fill-range": "^7.0.1"
           }
@@ -11544,19 +11871,22 @@
         "debug": {
           "version": "4.3.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.1.2"
           },
           "dependencies": {
             "ms": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "dir-glob": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "path-type": "^4.0.0"
           }
@@ -11564,11 +11894,13 @@
         "eslint-config-xo-typescript": {
           "version": "0.50.0",
           "bundled": true,
+          "dev": true,
           "requires": {}
         },
         "eslint-scope": {
           "version": "5.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "esrecurse": "^4.3.0",
             "estraverse": "^4.1.1"
@@ -11576,41 +11908,48 @@
           "dependencies": {
             "estraverse": {
               "version": "4.3.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "eslint-utils": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "eslint-visitor-keys": "^2.0.0"
           },
           "dependencies": {
             "eslint-visitor-keys": {
               "version": "2.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "eslint-visitor-keys": {
           "version": "3.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "esrecurse": {
           "version": "4.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "estraverse": "^5.2.0"
           }
         },
         "estraverse": {
           "version": "5.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fast-glob": {
           "version": "3.2.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
             "@nodelib/fs.walk": "^1.2.3",
@@ -11622,6 +11961,7 @@
         "fastq": {
           "version": "1.13.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "reusify": "^1.0.4"
           }
@@ -11629,6 +11969,7 @@
         "fill-range": {
           "version": "7.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "to-regex-range": "^5.0.1"
           }
@@ -11645,29 +11986,34 @@
         },
         "functional-red-black-tree": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "glob-parent": {
           "version": "5.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
         },
         "is-extglob": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-glob": {
           "version": "4.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-extglob": "^2.1.1"
           }
         },
         "is-number": {
           "version": "7.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "locate-path": {
           "version": "7.1.0",
@@ -11681,17 +12027,20 @@
         "lru-cache": {
           "version": "6.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "yallist": "^4.0.0"
           }
         },
         "merge2": {
           "version": "1.4.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "micromatch": {
           "version": "4.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "braces": "^3.0.1",
             "picomatch": "^2.2.3"
@@ -11723,27 +12072,33 @@
         },
         "path-type": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "picomatch": {
           "version": "2.3.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "queue-microtask": {
           "version": "1.2.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "regexpp": {
           "version": "3.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "reusify": {
           "version": "1.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "run-parallel": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "queue-microtask": "^1.2.2"
           }
@@ -11751,6 +12106,7 @@
         "semver": {
           "version": "7.3.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -11758,24 +12114,28 @@
         "to-regex-range": {
           "version": "5.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-number": "^7.0.0"
           }
         },
         "tslib": {
           "version": "1.14.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "tsutils": {
           "version": "3.21.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "tslib": "^1.8.1"
           }
         },
         "yallist": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yocto-queue": {
           "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "ISC",
       "dependencies": {
         "crypto-random-string": "^4.0.0",
-        "domain-info": "^0.1.2",
         "execa": "^6.1.0",
         "joi": "^17.6.0",
         "lodash": "^4.17.21",
+        "node-dig-dns": "^0.3.2",
         "physical-cpu-count": "^2.0.0",
         "socket.io-client": "^4.4.1",
         "throng": "^5.0.0",
@@ -142,6 +142,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
+      "integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+      "dependencies": {
+        "regenerator-runtime": "^0.13.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -501,11 +512,6 @@
       "resolved": "https://registry.npmjs.org/@types/throng/-/throng-5.0.3.tgz",
       "integrity": "sha512-Pt8Bunl40PyFvIcQ5berMYXt0XT94hWI4+5J7Ojl/k9NU75zHJibHUt3oRjiloy4x1rPcX0UJyq+yBjkMmv8zQ==",
       "dev": true
-    },
-    "node_modules/@types/tldjs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@types/tldjs/-/tldjs-1.7.1.tgz",
-      "integrity": "sha1-BdPvPLbgPPOt8eSgQ8FHDPIOF5k="
     },
     "node_modules/@ungap/promise-all-settled": {
       "version": "1.1.2",
@@ -893,14 +899,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -933,14 +931,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/binaryheap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/binaryheap/-/binaryheap-0.0.3.tgz",
-      "integrity": "sha1-DWE2yE6fGlqQwLlxeMPgDfWYINY=",
-      "engines": {
-        "node": ">= 0.6.0"
       }
     },
     "node_modules/brace-expansion": {
@@ -1001,17 +991,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "peer": true
-    },
-    "node_modules/buffercursor": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/buffercursor/-/buffercursor-0.0.12.tgz",
-      "integrity": "sha1-eKmn9DQ659ggqJmazIDeWR4lp3k=",
-      "dependencies": {
-        "verror": "^1.4.0"
-      },
-      "engines": {
-        "node": ">= 0.5.0"
-      }
     },
     "node_modules/builtin-modules": {
       "version": "3.2.0",
@@ -1341,11 +1320,6 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "node_modules/cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -1529,23 +1503,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/domain-info": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/domain-info/-/domain-info-0.1.2.tgz",
-      "integrity": "sha512-Rjva7t+L0RRnvFpTM6DNddjBx48CKMbzC75dcpAH5JBH+Lknfa1w/q/G5c0JwaH3HSI/Hf8/yCplzIC4JsXmIA==",
-      "dependencies": {
-        "@types/node": "^10.9.4",
-        "@types/tldjs": "^1.7.1",
-        "es6-promise": "^4.0.5",
-        "native-dns": "^0.7.0",
-        "tldjs": "^1.6.2"
-      }
-    },
-    "node_modules/domain-info/node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.82",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.82.tgz",
@@ -1701,11 +1658,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -2415,14 +2367,6 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
-    "node_modules/extsprintf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
-      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3082,14 +3026,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/ipaddr.js": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz",
-      "integrity": "sha1-qceMzBLckBDylqua7y9h9DLWnvo=",
-      "engines": {
-        "node": ">= 0.2.5"
-      }
-    },
     "node_modules/irregular-plurals": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
@@ -3740,6 +3676,11 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
+    "node_modules/lodash.compact": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
+      "integrity": "sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU="
+    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -4129,43 +4070,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/native-dns": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/native-dns/-/native-dns-0.7.0.tgz",
-      "integrity": "sha1-30GGNvCPsp6Py37xQsgioViLpbc=",
-      "dependencies": {
-        "ipaddr.js": "~0.1.3",
-        "native-dns-cache": "~0.0.2",
-        "native-dns-packet": "~0.1.1"
-      },
-      "engines": {
-        "node": ">= 0.5.0"
-      }
-    },
-    "node_modules/native-dns-cache": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/native-dns-cache/-/native-dns-cache-0.0.2.tgz",
-      "integrity": "sha1-zgmY9/32x5kJcKMxkGJLDpjulZs=",
-      "dependencies": {
-        "binaryheap": ">= 0.0.3",
-        "native-dns-packet": ">= 0.0.1"
-      },
-      "engines": {
-        "node": ">= 0.5.0"
-      }
-    },
-    "node_modules/native-dns-packet": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/native-dns-packet/-/native-dns-packet-0.1.1.tgz",
-      "integrity": "sha1-l9qQVwuEOKABlHAc4k0BH9PMEJo=",
-      "dependencies": {
-        "buffercursor": ">= 0.0.12",
-        "ipaddr.js": ">= 0.1.1"
-      },
-      "engines": {
-        "node": ">= 0.5.0"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -4190,6 +4094,15 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/node-dig-dns": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-dig-dns/-/node-dig-dns-0.3.2.tgz",
+      "integrity": "sha512-atYh7um4Yhs+4RfCyIXIOZDMCfMrcI9EKZAa1A98vpdZdUXNHcm1c4N/d2iktVOJBSwyHpf8Z9TOxv/3eJRkiQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "lodash.compact": "^3.0.1"
       }
     },
     "node_modules/node-releases": {
@@ -5002,6 +4915,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
     "node_modules/regexp-tree": {
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
@@ -5603,23 +5521,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/tldjs": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-1.8.0.tgz",
-      "integrity": "sha1-ucFr1t41e1X/y+fVvkH2s8p24/o=",
-      "hasInstallScript": true,
-      "dependencies": {
-        "punycode": "^1.4.1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/tldjs/node_modules/punycode": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-    },
     "node_modules/to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -5855,19 +5756,6 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
-      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
       }
     },
     "node_modules/watchpack": {
@@ -7152,6 +7040,14 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.7.tgz",
+      "integrity": "sha512-L6rvG9GDxaLgFjg41K+5Yv9OMrU98sWe+Ykmc6FDJW/+vYZMhdOMKkISgzptMaERHvS2Y2lw9MDRm2gHhlQQoA==",
+      "requires": {
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@bcoe/v8-coverage": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
@@ -7480,11 +7376,6 @@
       "integrity": "sha512-Pt8Bunl40PyFvIcQ5berMYXt0XT94hWI4+5J7Ojl/k9NU75zHJibHUt3oRjiloy4x1rPcX0UJyq+yBjkMmv8zQ==",
       "dev": true
     },
-    "@types/tldjs": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@types/tldjs/-/tldjs-1.7.1.tgz",
-      "integrity": "sha1-BdPvPLbgPPOt8eSgQ8FHDPIOF5k="
-    },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
@@ -7809,11 +7700,6 @@
       "integrity": "sha512-tLkvA81vQG/XqE2mjDkGQHoOINtMHtysSnemrmoGe6PydDPMRbVugqyk4A6V/WDWEfm3l+0d8anA9r8cv/5Jaw==",
       "dev": true
     },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -7841,11 +7727,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "binaryheap": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/binaryheap/-/binaryheap-0.0.3.tgz",
-      "integrity": "sha1-DWE2yE6fGlqQwLlxeMPgDfWYINY="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -7892,14 +7773,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "peer": true
-    },
-    "buffercursor": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/buffercursor/-/buffercursor-0.0.12.tgz",
-      "integrity": "sha1-eKmn9DQ659ggqJmazIDeWR4lp3k=",
-      "requires": {
-        "verror": "^1.4.0"
-      }
     },
     "builtin-modules": {
       "version": "3.2.0",
@@ -8165,11 +8038,6 @@
         }
       }
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "cosmiconfig": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
@@ -8297,25 +8165,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "domain-info": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/domain-info/-/domain-info-0.1.2.tgz",
-      "integrity": "sha512-Rjva7t+L0RRnvFpTM6DNddjBx48CKMbzC75dcpAH5JBH+Lknfa1w/q/G5c0JwaH3HSI/Hf8/yCplzIC4JsXmIA==",
-      "requires": {
-        "@types/node": "^10.9.4",
-        "@types/tldjs": "^1.7.1",
-        "es6-promise": "^4.0.5",
-        "native-dns": "^0.7.0",
-        "tldjs": "^1.6.2"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.17.60",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-          "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
-        }
       }
     },
     "electron-to-chromium": {
@@ -8448,11 +8297,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-promise": {
-      "version": "4.2.8",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
     },
     "escalade": {
       "version": "3.1.1",
@@ -8978,11 +8822,6 @@
         "strip-final-newline": "^3.0.0"
       }
     },
-    "extsprintf": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
-      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA=="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -9467,11 +9306,6 @@
       "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
       "dev": true
     },
-    "ipaddr.js": {
-      "version": "0.1.9",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.9.tgz",
-      "integrity": "sha1-qceMzBLckBDylqua7y9h9DLWnvo="
-    },
     "irregular-plurals": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/irregular-plurals/-/irregular-plurals-3.3.0.tgz",
@@ -9946,6 +9780,11 @@
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "dev": true
     },
+    "lodash.compact": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
+      "integrity": "sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU="
+    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -10240,34 +10079,6 @@
       "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
     },
-    "native-dns": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/native-dns/-/native-dns-0.7.0.tgz",
-      "integrity": "sha1-30GGNvCPsp6Py37xQsgioViLpbc=",
-      "requires": {
-        "ipaddr.js": "~0.1.3",
-        "native-dns-cache": "~0.0.2",
-        "native-dns-packet": "~0.1.1"
-      }
-    },
-    "native-dns-cache": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/native-dns-cache/-/native-dns-cache-0.0.2.tgz",
-      "integrity": "sha1-zgmY9/32x5kJcKMxkGJLDpjulZs=",
-      "requires": {
-        "binaryheap": ">= 0.0.3",
-        "native-dns-packet": ">= 0.0.1"
-      }
-    },
-    "native-dns-packet": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/native-dns-packet/-/native-dns-packet-0.1.1.tgz",
-      "integrity": "sha1-l9qQVwuEOKABlHAc4k0BH9PMEJo=",
-      "requires": {
-        "buffercursor": ">= 0.0.12",
-        "ipaddr.js": ">= 0.1.1"
-      }
-    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -10292,6 +10103,15 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node-dig-dns": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/node-dig-dns/-/node-dig-dns-0.3.2.tgz",
+      "integrity": "sha512-atYh7um4Yhs+4RfCyIXIOZDMCfMrcI9EKZAa1A98vpdZdUXNHcm1c4N/d2iktVOJBSwyHpf8Z9TOxv/3eJRkiQ==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "lodash.compact": "^3.0.1"
       }
     },
     "node-releases": {
@@ -10864,6 +10684,11 @@
         }
       }
     },
+    "regenerator-runtime": {
+      "version": "0.13.9",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
+      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+    },
     "regexp-tree": {
       "version": "0.1.24",
       "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.24.tgz",
@@ -11282,21 +11107,6 @@
         "lodash": "^4.17.20"
       }
     },
-    "tldjs": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tldjs/-/tldjs-1.8.0.tgz",
-      "integrity": "sha1-ucFr1t41e1X/y+fVvkH2s8p24/o=",
-      "requires": {
-        "punycode": "^1.4.1"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
-        }
-      }
-    },
     "to-absolute-glob": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
@@ -11468,16 +11278,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "verror": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
-      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "license": "ISC",
   "dependencies": {
     "crypto-random-string": "^4.0.0",
+    "domain-info": "^0.1.2",
     "execa": "^6.1.0",
     "joi": "^17.6.0",
     "lodash": "^4.17.21",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "license": "ISC",
   "dependencies": {
     "crypto-random-string": "^4.0.0",
-    "domain-info": "^0.1.2",
     "execa": "^6.1.0",
     "joi": "^17.6.0",
     "lodash": "^4.17.21",
+    "node-dig-dns": "^0.3.2",
     "physical-cpu-count": "^2.0.0",
     "socket.io-client": "^4.4.1",
     "throng": "^5.0.0",

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -30,8 +30,8 @@ const dnsOptionsSchema = Joi.object<DnsOptions>({
 });
 
 export const dnsCmd = async (options: DnsOptions): Promise<DnsQueryResult> => {
-	const protocolArg = options.query.protocol?.toLowerCase() === 'tcp' ? '+tcp' : '';
-	const resolverArg = options.query.resolver ? `@${options.query.resolver}` : '';
+	const protocolArg = options.query.protocol?.toLowerCase() === 'tcp' ? '+tcp' : [];
+	const resolverArg = options.query.resolver ? `@${options.query.resolver}` : [];
 
 	const args = [
 		options.target,

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -1,0 +1,80 @@
+import {getServers as getDnsServers} from 'node:dns';
+import Joi from 'joi';
+import type {Socket} from 'socket.io-client';
+import domain from 'domain-info';
+import type {CommandInterface} from '../types.js';
+import {InvalidOptionsException} from './exception/invalid-options-exception.js';
+
+type SingleDnsQueryResult = {
+	name: string;
+	type: string;
+	class: string;
+	address?: string;
+	primary?: string;
+	admin?: string;
+	serial?: number;
+	refresh?: number;
+	retry?: number;
+	expiration?: number;
+	minimum?: number;
+	data?: string[];
+};
+
+type DnsQueryResult = Record<string, SingleDnsQueryResult[]>;
+
+type DnsOptions = {
+	type: 'dns';
+	target: string;
+	query: {
+		types?: string[];
+		address?: string;
+		protocol?: string;
+		port?: number;
+	};
+};
+
+const defaultTypes = ['A', 'AAAA', 'ANY', 'CNAME', 'DNSKEY', 'DS', 'MX', 'NS', 'NSEC', 'PTR', 'RRSIG', 'SOA', 'TXT', 'SRV'];
+
+const dnsOptionsSchema = Joi.object<DnsOptions>({
+	type: Joi.string().valid('dns'),
+	target: Joi.string(),
+	query: Joi.object({
+		types: Joi.array().items(Joi.string().valid(...defaultTypes)).optional(),
+		address: Joi.string().optional(),
+		protocol: Joi.string().valid('TCP', 'UDP').optional(),
+		port: Joi.number().optional(),
+	}),
+});
+
+export const dnsCmd = async (options: DnsOptions): Promise<DnsQueryResult> => domain.groper(
+	options.target,
+	options.query.types ?? defaultTypes,
+	{
+		server: {
+			type: options.query.protocol ?? 'UDP',
+			address: options.query.address ?? getDnsServers().pop()!,
+			port: options.query.port ?? 53,
+		},
+	}) as DnsQueryResult;
+
+export class DnsCommand implements CommandInterface<DnsOptions> {
+	constructor(private readonly cmd: typeof dnsCmd) {}
+
+	async run(socket: Socket, measurementId: string, testId: string, options: unknown): Promise<void> {
+		const {value: cmdOptions, error} = dnsOptionsSchema.validate(options);
+
+		if (error) {
+			throw new InvalidOptionsException('dns', error);
+		}
+
+		const result = await this.cmd(cmdOptions);
+
+		console.log(result);
+
+		socket.emit('probe:measurement:result', {
+			testId,
+			measurementId,
+			result,
+		});
+	}
+}

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -38,7 +38,9 @@ export const dnsCmd = async (options: DnsOptions): Promise<DnsQueryResult> => {
 		resolverArg,
 		['-t', options.query.type],
 		['-p', options.query.port],
-		'-4', '+time=1', '+tries=2',
+		'-4',
+		'+time=1',
+		'+tries=2',
 		protocolArg,
 	].flat() as string[];
 

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -1,4 +1,3 @@
-import {getServers as getDnsServers} from 'node:dns';
 import Joi from 'joi';
 import type {Socket} from 'socket.io-client';
 import dig, {DnsQueryResult} from 'node-dig-dns';

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -23,7 +23,7 @@ const dnsOptionsSchema = Joi.object<DnsOptions>({
 	target: Joi.string(),
 	query: Joi.object({
 		type: Joi.string().valid(...allowedTypes).optional(),
-		address: Joi.string().optional(),
+		resolver: Joi.string().optional(),
 		protocol: Joi.string().valid().optional(),
 		port: Joi.number().optional(),
 	}),
@@ -31,10 +31,11 @@ const dnsOptionsSchema = Joi.object<DnsOptions>({
 
 export const dnsCmd = async (options: DnsOptions): Promise<DnsQueryResult> => {
 	const protocolArg = options.query.protocol?.toLowerCase() === 'tcp' ? '+tcp' : '';
+	const resolverArg = options.query.resolver ? `@${options.query.resolver}` : '';
 
 	const args = [
 		options.target,
-		`@${options.query.address ?? getDnsServers().pop()!}`,
+		resolverArg,
 		['-t', options.query.type ?? 'A'],
 		['-p', options.query.port ?? '53'],
 		'-4', '+time=1', '+tries=2',

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -37,6 +37,7 @@ export const dnsCmd = async (options: DnsOptions): Promise<DnsQueryResult> => {
 		`@${options.query.address ?? getDnsServers().pop()!}`,
 		['-t', options.query.type ?? 'A'],
 		['-p', options.query.port ?? '53'],
+		'-4', '+time=1', '+tries=2',
 		protocolArg,
 	].flat() as string[];
 

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -9,7 +9,7 @@ type DnsOptions = {
 	target: string;
 	query: {
 		type?: string[];
-		address?: string;
+		resolver?: string;
 		protocol?: string;
 		port?: number;
 	};

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -16,15 +16,16 @@ type DnsOptions = {
 };
 
 const allowedTypes = ['A', 'AAAA', 'ANY', 'CNAME', 'DNSKEY', 'DS', 'MX', 'NS', 'NSEC', 'PTR', 'RRSIG', 'SOA', 'TXT', 'SRV'];
+const allowedProtocols = ['UDP', 'TCP'];
 
 const dnsOptionsSchema = Joi.object<DnsOptions>({
 	type: Joi.string().valid('dns'),
 	target: Joi.string(),
 	query: Joi.object({
-		type: Joi.string().valid(...allowedTypes).optional(),
+		type: Joi.string().valid(...allowedTypes).optional().default('A'),
 		resolver: Joi.string().optional(),
-		protocol: Joi.string().valid().optional(),
-		port: Joi.number().optional(),
+		protocol: Joi.string().valid(...allowedProtocols).optional().default('udp'),
+		port: Joi.number().optional().default('53'),
 	}),
 });
 
@@ -35,8 +36,8 @@ export const dnsCmd = async (options: DnsOptions): Promise<DnsQueryResult> => {
 	const args = [
 		options.target,
 		resolverArg,
-		['-t', options.query.type ?? 'A'],
-		['-p', options.query.port ?? '53'],
+		['-t', options.query.type],
+		['-p', options.query.port],
 		'-4', '+time=1', '+tries=2',
 		protocolArg,
 	].flat() as string[];

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import type {CommandInterface, MeasurementRequest} from './types.js';
 import {scopedLogger} from './lib/logger.js';
 import {pingCmd, PingCommand} from './command/ping-command.js';
 import {traceCmd, TracerouteCommand} from './command/traceroute-command.js';
+import {dnsCmd, DnsCommand} from './command/dns-command.js';
 import {getConfValue} from './lib/config.js';
 
 const logger = scopedLogger('general');
@@ -14,6 +15,7 @@ const handlersMap = new Map<string, CommandInterface<any>>();
 
 handlersMap.set('ping', new PingCommand(pingCmd));
 handlersMap.set('traceroute', new TracerouteCommand(traceCmd));
+handlersMap.set('dns', new DnsCommand(dnsCmd));
 
 logger.info(`Start probe in a ${process.env['NODE_ENV'] ?? 'production'} mode`);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./dist",
     "moduleResolution": "node",
+    "paths": { "node-dig-dns": [ "./@types/node-dig-dns.d.ts" ] }
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
resolve #2

There's not many actively maintained libraries around, since node's official package resolves DNS pretty well (https://nodejs.org/api/dns.html).

It doesn't however seem to support protocol selection, so that won't work for us.

My initial commit implemented [domain-info](https://www.npmjs.com/package/domain-info) package, but I decided to ditch it since it doesn't seem to be actively maintained either, its last build failed. It supports multi dns type queries, which is interesting. The package @zarianec ([node-dig-dns](https://www.npmjs.com/package/node-dig-dns)) has proposed on the other hand, doesn't include types so they had to be included manually.

No tests, since theres nothing to test. Parsing is handled by the library.