### PR TITLE
11 pass probe version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ COPY --from=builder /app/package.json /app/package-lock.json /build/
 
 RUN npm install --production
 
-CMD ["node", "./dist/index.js"]
+CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "xo": "^0.48.0"
   },
   "scripts": {
+    "start": "node dist/index.js",
     "build": "tsc",
     "lint": "xo",
     "clean": "rimraf coverage",

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,9 @@ logger.info(`Start probe in a ${process.env['NODE_ENV'] ?? 'production'} mode`);
 function connect() {
 	const socket = io(`${getConfValue<string>('api.host')}/probes`, {
 		transports: ['websocket'],
+		query: {
+			version: process.env['npm_package_version'],
+		},
 	});
 
 	socket


### PR DESCRIPTION
resolve #11 

the probe server has to be started with NPM; it outputs `package.json` variables into `process.env`
https://docs.npmjs.com/cli/v8/using-npm/scripts

https://github.com/jsdelivr/globalping/pull/50