### PR TITLE
fix: add new packages to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,8 @@ FROM node:16-bullseye-slim
 ARG node_env=production
 ENV NODE_ENV=$node_env
 
-RUN apt update && apt install -y iputils-ping traceroute dnsutils curl jq tini \
-    && apt clean && apt autoremove -y \
+RUN apt-get update && apt-get install -y iputils-ping traceroute dnsutils curl jq tini mtr curl \
+    && apt-get clean && apt autoremove -y \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM node:16-bullseye-slim
 ARG node_env=production
 ENV NODE_ENV=$node_env
 
-RUN apt-get update && apt-get install -y iputils-ping traceroute dnsutils curl jq tini mtr curl \
+RUN apt-get update && apt-get install -y iputils-ping traceroute dnsutils jq tini mtr curl \
     && apt-get clean && apt autoremove -y \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 


### PR DESCRIPTION
I know we dont support them yet but since we assume users will rarely pull new Docker containers we will run into an issue where once we add support for them none of existing probes will be able to run them because there wont be a binary present.
So we should add all the binaries we might need right now. This way even the oldest probes will have them and will work fine after the code auto-update.

Am I missing any other packages?