### PR TITLE
ref: measurement results behaviour

### DIFF
--- a/@types/node-dig-dns.d.ts
+++ b/@types/node-dig-dns.d.ts
@@ -9,6 +9,8 @@ declare module 'node-dig-dns' {
 
 	export type DnsQueryResult = {
 		answer: SingleDnsQueryResult[];
+		time: number;
+		server: string;
 	};
 
 	export function dig(args: string[]): Promise<DnsQueryResult>;

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -62,7 +62,7 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 		socket.emit('probe:measurement:result', {
 			testId,
 			measurementId,
-			result: result.answer,
+			result: result.answer || {},
 		});
 	}
 }

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -62,7 +62,11 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 		socket.emit('probe:measurement:result', {
 			testId,
 			measurementId,
-			result: result.answer || {},
+			result: {
+				answer: result.answer || [],
+				time: result.time,
+				server: result.server,
+			},
 		});
 	}
 }

--- a/src/command/ping-command.ts
+++ b/src/command/ping-command.ts
@@ -48,12 +48,13 @@ export class PingCommand implements CommandInterface<PingOptions> {
 		});
 
 		let result = {};
+
 		try {
 			const cmdResult = await cmd;
 			result = this.parse(cmdResult.stdout);
 		} catch (error: unknown) {
 			result = {
-				rawOutput: (error as ExecaError).stderr.toString(),
+				rawOutput: (error as ExecaError).stderr?.toString() ?? '',
 			};
 		}
 

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -1,6 +1,6 @@
 import Joi from 'joi';
 import type {Socket} from 'socket.io-client';
-import {execa, ExecaChildProcess} from 'execa';
+import {execa, ExecaChildProcess, ExecaError} from 'execa';
 import type {CommandInterface} from '../types.js';
 import {InvalidOptionsException} from './exception/invalid-options-exception.js';
 
@@ -69,12 +69,20 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 			});
 		});
 
-		const result = await cmd;
+		let result = {};
+		try {
+			const cmdResult = await cmd;
+			result = this.parse(cmdResult.stdout);
+		} catch (error: unknown) {
+			result = {
+				rawOutput: (error as ExecaError).stderr.toString(),
+			};
+		}
 
 		socket.emit('probe:measurement:result', {
 			testId,
 			measurementId,
-			result: this.parse(result.stdout.trim()),
+			result,
 		});
 	}
 

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -75,7 +75,7 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 			result = this.parse(cmdResult.stdout.trim());
 		} catch (error: unknown) {
 			result = {
-				rawOutput: (error as ExecaError).stderr.toString(),
+				rawOutput: (error as ExecaError).stderr?.toString() ?? '',
 			};
 		}
 

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -72,7 +72,7 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 		let result = {};
 		try {
 			const cmdResult = await cmd;
-			result = this.parse(cmdResult.stdout);
+			result = this.parse(cmdResult.stdout.trim());
 		} catch (error: unknown) {
 			result = {
 				rawOutput: (error as ExecaError).stderr.toString(),


### PR DESCRIPTION
ping + traceroute:
captures the error, and returns `stderr` in `rawOutput` field.

dns:
returns an object with the following values:
`answer` - [array] array of results
`time` - [number] Query time.
`server` - [string] resolver. Plain response from the dig command.

https://github.com/jsdelivr/globalping/issues/61
https://github.com/jsdelivr/globalping/issues/62