### PR TITLE
feat: capture SIGTERM, close after job completion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as processTS from 'node:process';
+import process from 'node:process';
 import throng from 'throng';
 import {io} from 'socket.io-client';
 import cryptoRandomString from 'crypto-random-string';
@@ -24,7 +24,7 @@ handlersMap.set('ping', new PingCommand(pingCmd));
 handlersMap.set('traceroute', new TracerouteCommand(traceCmd));
 handlersMap.set('dns', new DnsCommand(dnsCmd));
 
-logger.info(`Start probe version ${VERSION} in a ${processTS.env['NODE_ENV'] ?? 'production'} mode`);
+logger.info(`Start probe version ${VERSION} in a ${process.env['NODE_ENV'] ?? 'production'} mode`);
 
 function connect() {
 	const worker = {
@@ -76,7 +76,6 @@ function connect() {
 			});
 		});
 
-	// eslint-disable-next-line node/prefer-global/process
 	process.on('SIGTERM', () => {
 		worker.active = false;
 		socket.emit('probe:status:not_ready', {});
@@ -88,14 +87,13 @@ function connect() {
 				clearInterval(closeInterval);
 
 				logger.debug('closing process');
-				// eslint-disable-next-line node/prefer-global/process
 				process.exit(0);
 			}
 		}, 100);
 	});
 }
 
-if (processTS.env['NODE_ENV'] === 'development') {
+if (process.env['NODE_ENV'] === 'development') {
 	// Run multiple clients in dev mode for easier debugging
 	throng({worker: connect, count: physicalCpuCount})
 		.catch(error => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import * as processTS from 'node:process';
 import throng from 'throng';
 import {io} from 'socket.io-client';
 import cryptoRandomString from 'crypto-random-string';
@@ -24,9 +24,14 @@ handlersMap.set('ping', new PingCommand(pingCmd));
 handlersMap.set('traceroute', new TracerouteCommand(traceCmd));
 handlersMap.set('dns', new DnsCommand(dnsCmd));
 
-logger.info(`Start probe version ${VERSION} in a ${process.env['NODE_ENV'] ?? 'production'} mode`);
+logger.info(`Start probe version ${VERSION} in a ${processTS.env['NODE_ENV'] ?? 'production'} mode`);
 
 function connect() {
+	const worker = {
+		jobs: new Map<string, number>(),
+		active: false,
+	};
+
 	const socket = io(`${getConfValue<string>('api.host')}/probes`, {
 		transports: ['websocket'],
 		query: {
@@ -41,8 +46,14 @@ function connect() {
 		.on('api:error', apiErrorHandler)
 		.on('api:connect:location', apiConnectLocationHandler)
 		.on('probe:measurement:request', (data: MeasurementRequest) => {
+			if (!worker.active) {
+				return;
+			}
+
 			const {id: measurementId, measurement} = data;
 			const testId = cryptoRandomString({length: 16, type: 'alphanumeric'});
+
+			worker.jobs.set(measurementId, Date.now());
 
 			logger.debug(`${measurement.type} request ${data.id} received`, data);
 			socket.emit('probe:measurement:ack', {id: testId, measurementId}, async () => {
@@ -53,19 +64,38 @@ function connect() {
 
 				try {
 					await handler.run(socket, measurementId, testId, measurement);
+					worker.jobs.delete(measurementId);
+					console.log('sas:');
 				} catch (error: unknown) {
 					// Todo: maybe we should notify api as well
 					logger.error('failed to run the measurement.', error);
 				}
 			});
 		});
+
+	// eslint-disable-next-line node/prefer-global/process
+	process.on('SIGTERM', () => {
+		worker.active = false;
+		logger.debug('SIGTERM received');
+
+		const closeInterval = setInterval(() => {
+			if (worker.jobs.size === 0) {
+				clearInterval(closeInterval);
+
+				logger.debug('closing process');
+				// eslint-disable-next-line node/prefer-global/process
+				process.exit(0);
+			}
+		}, 100);
+	});
 }
 
-if (process.env['NODE_ENV'] === 'development') {
+if (processTS.env['NODE_ENV'] === 'development') {
 	// Run multiple clients in dev mode for easier debugging
-	throng({worker: connect, count: physicalCpuCount}).catch(error => {
-		logger.error(error);
-	});
+	throng({worker: connect, count: physicalCpuCount})
+		.catch(error => {
+			logger.error(error);
+		});
 } else {
 	connect();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,11 @@ function connect() {
 	});
 
 	socket
-		.on('connect', () => logger.debug('connection to API established'))
+		.on('connect', () => {
+			worker.active = true;
+			socket.emit('probe:status:ready', {});
+			logger.debug('connection to API established');
+		})
 		.on('disconnect', () => logger.debug('disconnected from API'))
 		.on('connect_error', error => logger.error('connection to API failed', error))
 		.on('api:error', apiErrorHandler)
@@ -76,6 +80,8 @@ function connect() {
 	// eslint-disable-next-line node/prefer-global/process
 	process.on('SIGTERM', () => {
 		worker.active = false;
+		socket.emit('probe:status:not_ready', {});
+
 		logger.debug('SIGTERM received');
 
 		const closeInterval = setInterval(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -69,7 +69,6 @@ function connect() {
 				try {
 					await handler.run(socket, measurementId, testId, measurement);
 					worker.jobs.delete(measurementId);
-					console.log('sas:');
 				} catch (error: unknown) {
 					// Todo: maybe we should notify api as well
 					logger.error('failed to run the measurement.', error);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import process from 'node:process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import _ from 'lodash';

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,4 +1,4 @@
-import * as process from 'node:process';
+import process from 'node:process';
 import * as winston from 'winston';
 
 const logger = winston.createLogger({

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -26,8 +26,7 @@ const checkForUpdates = async () => {
 		currentVersion: VERSION,
 	});
 
-	/* eslint-disable-next-line unicorn/no-process-exit */
-	process.exit();
+	process.kill(process.pid, 'SIGTERM');
 };
 
 if (process.env['NODE_ENV'] !== 'development') {


### PR DESCRIPTION
resolve #17

- dont accept new connections, until `connect` event is received
- on `connect` emit `probe:status:ready` event
- on `SIGTERM` emit `probe:status:not_ready` event
- on `SIGTERM` block new measurement requests
- send `SIGTERM` on update completion
- on `SIGTERM`, don't close the app until all jobs are completed