### PR TITLE
improvement: update-ca-certificates

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+update-ca-certificates
+
 function run_probe() {
   node /app/dist/index.js
   return


### PR DESCRIPTION
Since we assume the container will never get updated it will break HTTPS sooner or later due to expired certs. So my idea is to run `update-ca-certificates` to update them before downloading an agent update. 