### PR TITLE
feat: health restart every ~7 days

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -6,5 +6,10 @@
     "releaseUrl": "https://api.github.com/repos/jsdelivr/globalping-probe/releases/latest",
     "interval": 300,
     "maxDeviation": 300
+  },
+  "uptime": {
+    "interval": 1,
+    "maxDeviation": 300,
+    "maxUptime": 43200
   }
 }

--- a/config/default.json
+++ b/config/default.json
@@ -8,8 +8,8 @@
     "maxDeviation": 300
   },
   "uptime": {
-    "interval": 1,
-    "maxDeviation": 300,
-    "maxUptime": 43200
+    "interval": 300,
+    "maxDeviation": 86400,
+    "maxUptime": 604800
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,9 @@ import {VERSION} from './constants.js';
 // Run self-update checks
 import './lib/updater.js';
 
+// Run scheduled restart
+import './lib/restart.js';
+
 const logger = scopedLogger('general');
 const handlersMap = new Map<string, CommandInterface<any>>();
 

--- a/src/lib/restart.ts
+++ b/src/lib/restart.ts
@@ -1,0 +1,19 @@
+import process from 'node:process';
+import _ from 'lodash';
+import {getConfValue} from './config.js';
+import {scopedLogger} from './logger.js';
+
+const logger = scopedLogger('health-restart');
+const uptimeConfig = getConfValue<{interval: number; maxDeviation: number; maxUptime: number}>('uptime');
+const uptimeInterval = uptimeConfig.interval + _.random(0, uptimeConfig.maxDeviation);
+
+const checkUptime = () => {
+	const uptime = process.uptime();
+
+	if (uptime >= uptimeConfig.maxUptime) {
+		logger.info('Scheduled Probe restart. Sending SIGTERM', {maxUptime: uptimeConfig.maxUptime});
+		process.kill(process.pid, 'SIGTERM');
+	}
+};
+
+setInterval(checkUptime, uptimeInterval * 1000);


### PR DESCRIPTION
#38

Sends `SIGTERM` signal every 12 hrs. 

It doesn't rely on #31, but it would be better to merge it first.