### PR TITLE
fix: connect stops reconnect handler

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,9 @@ function connect() {
 		.on('connect', () => logger.debug('connection to API established'))
 		.on('disconnect', (reason: string): void => {
 			logger.debug(`disconnected from API. (${reason})`);
-			socket.connect();
+			if (reason === 'io server disconnect') {
+				socket.connect();
+			}
 		})
 		.on('connect_error', error => {
 			logger.error('connection to API failed', error);


### PR DESCRIPTION
initial problem:
probes don't reconnect after server initiated `disconnect`

current problem:
probes don't reconnect after their first `connect` failure.

reasoning:
the client doesn't attempt to reconnect on an explicit `disconnect` request. However, forcing a `connect` attempt while the client's `reconnect` handler is enabled, causes the `reconnect` handler to quit. We have to isolate the reason of the disconnect and only manually reconnect if the reconnect handler isn't running.