### PR TITLE
fix: private IP - prevent progress update

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -83,6 +83,7 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 
 			if (!isValid) {
 				isResultPrivate = !isValid;
+				return;
 			}
 
 			socket.emit('probe:measurement:progress', {

--- a/src/command/ping-command.ts
+++ b/src/command/ping-command.ts
@@ -51,6 +51,7 @@ export class PingCommand implements CommandInterface<PingOptions> {
 
 			if (!isValid) {
 				isResultPrivate = !isValid;
+				return;
 			}
 
 			socket.emit('probe:measurement:progress', {

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -72,6 +72,7 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 
 			if (!isValid) {
 				isResultPrivate = !isValid;
+				return;
 			}
 
 			socket.emit('probe:measurement:progress', {


### PR DESCRIPTION
Just for good measure. Normally this shouldn't be an issue, and I'm unable to replicate it under any circumstances, since the `probe:measurement:result` event kicks in immidatelly.

related to https://github.com/jsdelivr/globalping/issues/134