### PR TITLE
fix: http error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "is-ip": "^4.0.0",
         "joi": "^17.6.0",
         "lodash": "^4.17.21",
+        "nock": "^13.2.7",
         "physical-cpu-count": "^2.0.0",
         "private-ip": "^2.3.3",
         "socket.io-client": "^4.4.1",
@@ -5731,8 +5732,7 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "node_modules/json5": {
       "version": "2.2.1",
@@ -6434,6 +6434,20 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "node_modules/nock": {
+      "version": "13.2.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.7.tgz",
+      "integrity": "sha512-R6NUw7RIPtKwgK7jskuKoEi4VFMqIHtV2Uu9K/Uegc4TA5cqe+oNMYslZcUmnVNQCTG6wcSqUBaGTDd7sq5srg==",
+      "dependencies": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 10.13"
       }
     },
     "node_modules/node-emoji": {
@@ -9620,6 +9634,14 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "node_modules/propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/proto-props": {
       "version": "2.0.0",
@@ -17281,8 +17303,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.2.1",
@@ -17819,6 +17840,17 @@
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
         "path-to-regexp": "^1.7.0"
+      }
+    },
+    "nock": {
+      "version": "13.2.7",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.2.7.tgz",
+      "integrity": "sha512-R6NUw7RIPtKwgK7jskuKoEi4VFMqIHtV2Uu9K/Uegc4TA5cqe+oNMYslZcUmnVNQCTG6wcSqUBaGTDd7sq5srg==",
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.21",
+        "propagate": "^2.0.0"
       }
     },
     "node-emoji": {
@@ -20053,6 +20085,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag=="
     },
     "proto-props": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "is-ip": "^4.0.0",
     "joi": "^17.6.0",
     "lodash": "^4.17.21",
+    "nock": "^13.2.7",
     "physical-cpu-count": "^2.0.0",
     "private-ip": "^2.3.3",
     "socket.io-client": "^4.4.1",

--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -27,6 +27,18 @@ export type Timings = {
 	phases: Record<string, number>;
 };
 
+const getInitialResult = () => ({
+	tls: {},
+	error: '',
+	headers: {},
+	rawHeaders: '',
+	curlHeaders: '',
+	rawBody: '',
+	statusCode: 0,
+	httpVersion: '',
+	timings: {},
+});
+
 const allowedHttpProtocols = ['http', 'https', 'http2'];
 const allowedHttpMethods = ['get', 'head'];
 export const httpOptionsSchema = Joi.object<HttpOptions>({
@@ -88,19 +100,9 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 
 		const stream = this.cmd(cmdOptions);
 
-		const result = {
-			tls: {},
-			error: '',
-			headers: {},
-			rawHeaders: '',
-			curlHeaders: '',
-			rawBody: '',
-			statusCode: 0,
-			httpVersion: '',
-			timings: {},
-		};
+		let result = getInitialResult();
 
-		const respond = () => {
+		const respond = (resolve: () => void) => {
 			const timings = (stream.timings ?? {}) as Timings;
 			if (!timings['end']) {
 				timings['end'] = Date.now();
@@ -129,9 +131,28 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 					rawOutput: result.error || rawOutput,
 				},
 			});
+
+			resolve();
 		};
 
-		stream.on('downloadProgress', (progress: Progress) => {
+		const onData = (data: Buffer) => {
+			result.rawBody += data.toString();
+
+			socket.emit('probe:measurement:progress', {
+				testId,
+				measurementId,
+				result: {rawOutput: data.toString()},
+			});
+		};
+
+		const onResponse = (resp: Response) => {
+			result = {
+				...result,
+				...this.parseResponse(resp),
+			};
+		};
+
+		const onDownloadProgress = (progress: Progress) => {
 			const {downloadLimit} = stream.options.context;
 
 			if (!downloadLimit) {
@@ -141,66 +162,69 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 			if (progress.transferred > Number(downloadLimit) && progress.percent !== 1) {
 				stream.destroy(new Error('Exceeded the download.'));
 			}
-		});
+		};
 
-		stream.on('data', (data: Buffer) => {
-			result.rawBody += data.toString();
+		const pStream = new Promise((resolve, _reject) => {
+			const onResolve = () => {
+				resolve(null);
+			};
 
-			socket.emit('probe:measurement:progress', {
-				testId,
-				measurementId,
-				result: {rawOutput: data.toString()},
+			stream.on('downloadProgress', onDownloadProgress);
+			stream.on('data', onData);
+			stream.on('response', onResponse);
+
+			stream.on('error', (error: Error & {code: string}) => {
+				// Skip error mapping on download limit
+				if (error.message !== 'Exceeded the download.') {
+					result.error = `${error.message} - ${error.code}`;
+				}
+
+				respond(onResolve);
+			});
+
+			stream.on('end', () => {
+				respond(onResolve);
 			});
 		});
 
-		stream.on('response', (resp: Response) => {
-			// Headers
-			const rawHeaders = _.chunk(resp.rawHeaders, 2).map((g: string[]) => `${String(g[0])}: ${String(g[1])}`);
-			result.rawHeaders = rawHeaders.join('\n');
-			result.curlHeaders = rawHeaders.filter((r: string) => !r.startsWith(':status:')).join('\n');
-			result.headers = resp.headers;
+		await pStream;
+	}
 
-			result.statusCode = resp.statusCode;
-			result.httpVersion = resp.httpVersion;
+	private parseResponse(resp: Response) {
+		const result = getInitialResult();
 
-			result.timings = {
-				firstByte: resp.timings.phases.firstByte,
-				dns: resp.timings.phases.dns,
-				tls: resp.timings.phases.tls,
-				tcp: resp.timings.phases.tcp,
+		// Headers
+		const rawHeaders = _.chunk(resp.rawHeaders, 2).map((g: string[]) => `${String(g[0])}: ${String(g[1])}`);
+		result.rawHeaders = rawHeaders.join('\n');
+		result.curlHeaders = rawHeaders.filter((r: string) => !r.startsWith(':status:')).join('\n');
+		result.headers = resp.headers;
+
+		result.statusCode = resp.statusCode;
+		result.httpVersion = resp.httpVersion;
+
+		result.timings = {
+			firstByte: resp.timings.phases.firstByte,
+			dns: resp.timings.phases.dns,
+			tls: resp.timings.phases.tls,
+			tcp: resp.timings.phases.tcp,
+		};
+
+		const rSocket = resp.socket;
+		if (isTlsSocket(rSocket)) {
+			const cert = rSocket.getPeerCertificate();
+			result.tls = {
+				authorized: rSocket.authorized,
+				...(rSocket.authorizationError ? {error: rSocket.authorizationError} : {}),
+				createdAt: cert.valid_from,
+				expireAt: cert.valid_to,
+				issuer: {...cert.issuer},
+				subject: {
+					...cert.subject,
+					alt: cert.subjectaltname,
+				},
 			};
+		}
 
-			const rSocket = resp.socket;
-			if (isTlsSocket(rSocket)) {
-				const cert = rSocket.getPeerCertificate();
-				result.tls = {
-					authorized: rSocket.authorized,
-					...(rSocket.authorizationError ? {error: rSocket.authorizationError} : {}),
-					createdAt: cert.valid_from,
-					expireAt: cert.valid_to,
-					issuer: {...cert.issuer},
-					subject: {
-						...cert.subject,
-						alt: cert.subjectaltname,
-					},
-				};
-			}
-		});
-
-		stream.on('error', (error: Error & {code: string}) => {
-			// Skip error mapping on download limit
-			if (error.message !== 'Exceeded the download.') {
-				result.error = `${error.message} - ${error.code}`;
-			}
-
-			respond();
-		});
-
-		stream.on('end', () => {
-			respond();
-		});
-
-		// eslint-disable-next-line unicorn/no-useless-promise-resolve-reject
-		return Promise.resolve();
+		return result;
 	}
 }

--- a/test/unit/cmd/http.test.ts
+++ b/test/unit/cmd/http.test.ts
@@ -1,9 +1,13 @@
 import {PassThrough} from 'node:stream';
+import nock from 'nock';
 import type {Request} from 'got';
 import * as sinon from 'sinon';
 import {expect} from 'chai';
 import {Socket} from 'socket.io-client';
-import {HttpCommand} from '../../../src/command/http-command.js';
+import {
+	HttpCommand,
+	httpCmd,
+} from '../../../src/command/http-command.js';
 import type {Timings} from '../../../src/command/http-command.js';
 
 type StreamCert = {
@@ -69,313 +73,399 @@ describe('http command', () => {
 		sandbox.reset();
 	});
 
-	it('should emit progress + result events', async () => {
-		const options = {
-			type: 'http',
-			target: 'google.com',
-			query: {
-				method: 'get',
-				protocol: 'http',
-				path: '/',
-			},
-		};
+	describe('with httCmd', () => {
+		nock('http://google.com')
+			.get('/400')
+			.times(2)
+			.reply(400, '400 Bad Request', {
+				test: 'abc',
+			});
 
-		const events = {
-			response: {
-				socket: {},
-				statusCode: 200,
-				httpVersion: '1.1',
-				timings: {
-					start: 0,
-					phases: {
-						tls: 2,
-						tcp: 2,
-						dns: 5,
-						download: 10,
-						total: 11,
-						firstByte: 1,
+		it('should respond with 400', async () => {
+			const options = {
+				type: 'http',
+				target: 'google.com',
+				query: {
+					method: 'get',
+					protocol: 'http',
+					path: '/400',
+				},
+			};
+
+			const expectedResult = {
+				measurementId: 'measurement',
+				result: {
+					headers: {
+						test: 'abc',
 					},
+					rawHeaders: 'test: abc',
+					rawBody: '400 Bad Request',
+					rawOutput: '400 Bad Request',
+					statusCode: 400,
 				},
-				headers: {test: 'abc'},
-				rawHeaders: ['test', 'abc'],
-			},
-			data: ['abc', 'def', 'ghi'],
-		};
+				testId: 'test',
+			};
 
-		const response = {
-			...events.response,
-		};
+			const http = new HttpCommand(httpCmd);
+			await http.run(mockedSocket as any, 'measurement', 'test', options);
 
-		const expectedResult = {
-			measurementId: 'measurement',
-			result: {
-				headers: {
-					test: 'abc',
+			expect(mockedSocket.emit.firstCall.args[0]).to.equal('probe:measurement:progress');
+			expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
+			expect(mockedSocket.emit.lastCall.args[1]).to.have.nested.property('result.rawBody', expectedResult.result.rawBody);
+			expect(mockedSocket.emit.lastCall.args[1]).to.have.nested.property('result.rawHeaders', expectedResult.result.rawHeaders);
+		});
+
+		it('should respond with 400 (missing path slash)', async () => {
+			const options = {
+				type: 'http',
+				target: 'google.com',
+				query: {
+					method: 'get',
+					protocol: 'http',
+					path: '400',
 				},
-				timings: {
-					dns: 5,
-					tls: 2,
-					tcp: 2,
-					download: 10,
-					firstByte: 1,
-					total: 11,
+			};
+
+			const expectedResult = {
+				measurementId: 'measurement',
+				result: {
+					headers: {
+						test: 'abc',
+					},
+					rawHeaders: 'test: abc',
+					rawBody: '400 Bad Request',
+					rawOutput: '400 Bad Request',
+					statusCode: 400,
 				},
-				rawHeaders: 'test: abc',
-				rawBody: 'abcdefghi',
-				rawOutput: 'abcdefghi',
-				statusCode: 200,
-				tls: {},
-			},
-			testId: 'test',
-		};
+				testId: 'test',
+			};
 
-		const stream = new Stream(response);
-		const httpCmd = (): Request => stream as never;
+			const http = new HttpCommand(httpCmd);
+			await http.run(mockedSocket as any, 'measurement', 'test', options);
 
-		const http = new HttpCommand(httpCmd);
-		await http.run(mockedSocket as any, 'measurement', 'test', options);
-
-		stream.emit('response', events.response);
-
-		for (const data of events.data) {
-			stream.emit('data', Buffer.from(data));
-		}
-
-		stream.emit('end');
-
-		expect(mockedSocket.emit.firstCall.args[0]).to.equal('probe:measurement:progress');
-		expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
-		expect(mockedSocket.emit.lastCall.args[1]).to.deep.equal(expectedResult);
-		expect(mockedSocket.emit.callCount).to.equal(4);
+			expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
+			expect(mockedSocket.emit.lastCall.args[1]).to.have.nested.property('result.rawBody', expectedResult.result.rawBody);
+			expect(mockedSocket.emit.lastCall.args[1]).to.have.nested.property('result.rawHeaders', expectedResult.result.rawHeaders);
+		});
 	});
 
-	it('should emit headers (rawOutput - HEAD request)', async () => {
-		const options = {
-			type: 'http',
-			target: 'google.com',
-			query: {
-				method: 'head',
-				protocol: 'http',
-				path: '/',
-			},
-		};
+	describe('manual', () => {
+		it('should emit progress + result events', async () => {
+			const options = {
+				type: 'http',
+				target: 'google.com',
+				query: {
+					method: 'get',
+					protocol: 'http',
+					path: '/',
+				},
+			};
 
-		const events = {
-			response: {
-				socket: {},
-				statusCode: 200,
-				timings: {
-					start: 0,
-					phases: {
-						download: 10,
-						total: 11,
+			const events = {
+				response: {
+					socket: {},
+					statusCode: 200,
+					httpVersion: '1.1',
+					timings: {
+						start: 0,
+						phases: {
+							tls: 2,
+							tcp: 2,
+							dns: 5,
+							download: 10,
+							total: 11,
+							firstByte: 1,
+						},
+					},
+					headers: {test: 'abc'},
+					rawHeaders: ['test', 'abc'],
+				},
+				data: ['abc', 'def', 'ghi'],
+			};
+
+			const response = {
+				...events.response,
+			};
+
+			const expectedResult = {
+				measurementId: 'measurement',
+				result: {
+					headers: {
+						test: 'abc',
+					},
+					timings: {
 						dns: 5,
+						tls: 2,
+						tcp: 2,
+						download: 10,
+						firstByte: 1,
+						total: 11,
+					},
+					rawHeaders: 'test: abc',
+					rawBody: 'abcdefghi',
+					rawOutput: 'abcdefghi',
+					statusCode: 200,
+					tls: {},
+				},
+				testId: 'test',
+			};
+
+			const stream = new Stream(response);
+			const mockHttpCmd = (): Request => stream as never;
+
+			const http = new HttpCommand(mockHttpCmd);
+			const cmd = http.run(mockedSocket as any, 'measurement', 'test', options);
+
+			stream.emit('response', events.response);
+
+			for (const data of events.data) {
+				stream.emit('data', Buffer.from(data));
+			}
+
+			stream.emit('end');
+
+			await cmd;
+
+			expect(mockedSocket.emit.firstCall.args[0]).to.equal('probe:measurement:progress');
+			expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
+			expect(mockedSocket.emit.lastCall.args[1]).to.deep.equal(expectedResult);
+			expect(mockedSocket.emit.callCount).to.equal(4);
+		});
+
+		it('should emit headers (rawOutput - HEAD request)', async () => {
+			const options = {
+				type: 'http',
+				target: 'google.com',
+				query: {
+					method: 'head',
+					protocol: 'http',
+					path: '/',
+				},
+			};
+
+			const events = {
+				response: {
+					socket: {},
+					statusCode: 200,
+					timings: {
+						start: 0,
+						phases: {
+							download: 10,
+							total: 11,
+							dns: 5,
+							tls: 5,
+							tcp: 2,
+							firstByte: 1,
+						},
+					},
+					httpVersion: '1.1',
+					headers: {test: 'abc'},
+					rawHeaders: ['test', 'abc'],
+				},
+			};
+
+			const response = {
+				...events.response,
+			};
+
+			const expectedResult = {
+				measurementId: 'measurement',
+				result: {
+					headers: {
+						test: 'abc',
+					},
+					timings: {
+						dns: 5,
+						total: 11,
 						tls: 5,
 						tcp: 2,
 						firstByte: 1,
-					},
-				},
-				httpVersion: '1.1',
-				headers: {test: 'abc'},
-				rawHeaders: ['test', 'abc'],
-			},
-		};
-
-		const response = {
-			...events.response,
-		};
-
-		const expectedResult = {
-			measurementId: 'measurement',
-			result: {
-				headers: {
-					test: 'abc',
-				},
-				timings: {
-					dns: 5,
-					total: 11,
-					tls: 5,
-					tcp: 2,
-					firstByte: 1,
-					download: 10,
-				},
-				rawHeaders: 'test: abc',
-				rawBody: '',
-				rawOutput: 'HTTP/1.1 200\ntest: abc',
-				statusCode: 200,
-				tls: {},
-			},
-			testId: 'test',
-		};
-
-		const stream = new Stream(response);
-		const httpCmd = (): Request => stream as never;
-
-		const http = new HttpCommand(httpCmd);
-		await http.run(mockedSocket as any, 'measurement', 'test', options);
-
-		stream.emit('response', events.response);
-		stream.emit('end');
-
-		expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
-		expect(mockedSocket.emit.lastCall.args[1]).to.deep.equal(expectedResult);
-	});
-
-	it('should filter out :status header (HTTP/2 - rawHeader)', async () => {
-		const options = {
-			type: 'http',
-			target: 'google.com',
-			query: {
-				method: 'head',
-				protocol: 'http',
-				path: '/',
-			},
-		};
-
-		/* eslint-disable @typescript-eslint/naming-convention */
-		const cert = {
-			valid_from: 100,
-			valid_to: 200,
-			issuer: {
-				CN: 'abc ltd',
-			},
-			subject: {
-				CN: 'defllc.dom',
-			},
-			subjectaltname: 'DNS:defllc.com, DNS:*.defllc.com',
-		};
-		/* eslint-enable @typescript-eslint/naming-convention */
-
-		const events = {
-			response: {
-				socket: {
-					authorized: true,
-					getPeerCertificate: () => cert,
-				},
-				statusCode: 200,
-				timings: {
-					start: 0,
-					phases: {
 						download: 10,
-						total: 11,
+					},
+					rawHeaders: 'test: abc',
+					rawBody: '',
+					rawOutput: 'HTTP/1.1 200\ntest: abc',
+					statusCode: 200,
+					tls: {},
+				},
+				testId: 'test',
+			};
+
+			const stream = new Stream(response);
+			const mockHttpCmd = (): Request => stream as never;
+
+			const http = new HttpCommand(mockHttpCmd);
+			const cmd = http.run(mockedSocket as any, 'measurement', 'test', options);
+
+			stream.emit('response', events.response);
+			stream.emit('end');
+
+			await cmd;
+
+			expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
+			expect(mockedSocket.emit.lastCall.args[1]).to.deep.equal(expectedResult);
+		});
+
+		it('should filter out :status header (HTTP/2 - rawHeader)', async () => {
+			const options = {
+				type: 'http',
+				target: 'google.com',
+				query: {
+					method: 'head',
+					protocol: 'http',
+					path: '/',
+				},
+			};
+
+			/* eslint-disable @typescript-eslint/naming-convention */
+			const cert = {
+				valid_from: 100,
+				valid_to: 200,
+				issuer: {
+					CN: 'abc ltd',
+				},
+				subject: {
+					CN: 'defllc.dom',
+				},
+				subjectaltname: 'DNS:defllc.com, DNS:*.defllc.com',
+			};
+			/* eslint-enable @typescript-eslint/naming-convention */
+
+			const events = {
+				response: {
+					socket: {
+						authorized: true,
+						getPeerCertificate: () => cert,
+					},
+					statusCode: 200,
+					timings: {
+						start: 0,
+						phases: {
+							download: 10,
+							total: 11,
+							tls: 2,
+							tcp: 2,
+							dns: 5,
+							firstByte: 1,
+						},
+					},
+					httpVersion: '2',
+					headers: {test: 'abc'},
+					rawHeaders: [':status', 200, 'test', 'abc'],
+				},
+			};
+
+			const response = {
+				...events.response,
+			};
+
+			const expectedResult = {
+				measurementId: 'measurement',
+				result: {
+					headers: {
+						test: 'abc',
+					},
+					timings: {
 						tls: 2,
 						tcp: 2,
+						total: 11,
 						dns: 5,
 						firstByte: 1,
+						download: 10,
+					},
+					tls: {
+						authorized: true,
+						createdAt: 100,
+						expireAt: 200,
+						issuer: {
+							...cert.issuer,
+						},
+						subject: {
+							...cert.subject,
+							alt: cert.subjectaltname,
+						},
+					},
+					rawHeaders: ':status: 200\ntest: abc',
+					rawBody: '',
+					rawOutput: 'HTTP/2 200\ntest: abc',
+					statusCode: 200,
+				},
+				testId: 'test',
+			};
+
+			const stream = new Stream(response);
+			const mockHttpCmd = (): Request => stream as never;
+
+			const http = new HttpCommand(mockHttpCmd);
+			const cmd = http.run(mockedSocket as any, 'measurement', 'test', options);
+
+			stream.emit('response', events.response);
+			stream.emit('end');
+
+			await cmd;
+
+			expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
+			expect(mockedSocket.emit.lastCall.args[1]).to.deep.equal(expectedResult);
+		});
+
+		it('should emit error', async () => {
+			const options = {
+				type: 'http',
+				target: 'google.com',
+				query: {
+					method: 'get',
+					protocol: 'http',
+					path: '/',
+				},
+			};
+
+			const events = {
+				response: {
+					socket: {},
+					timings: {
+						phases: {
+							download: 10,
+							total: 11,
+						},
 					},
 				},
-				httpVersion: '2',
-				headers: {test: 'abc'},
-				rawHeaders: [':status', 200, 'test', 'abc'],
-			},
-		};
+				error: new HttpError('ENODATA google.com', 'abc'),
+			};
 
-		const response = {
-			...events.response,
-		};
+			const response = {
+				...events.response,
+			};
 
-		const expectedResult = {
-			measurementId: 'measurement',
-			result: {
-				headers: {
-					test: 'abc',
-				},
-				timings: {
-					tls: 2,
-					tcp: 2,
-					total: 11,
-					dns: 5,
-					firstByte: 1,
-					download: 10,
-				},
-				tls: {
-					authorized: true,
-					createdAt: 100,
-					expireAt: 200,
-					issuer: {
-						...cert.issuer,
-					},
-					subject: {
-						...cert.subject,
-						alt: cert.subjectaltname,
-					},
-				},
-				rawHeaders: ':status: 200\ntest: abc',
-				rawBody: '',
-				rawOutput: 'HTTP/2 200\ntest: abc',
-				statusCode: 200,
-			},
-			testId: 'test',
-		};
-
-		const stream = new Stream(response);
-		const httpCmd = (): Request => stream as never;
-
-		const http = new HttpCommand(httpCmd);
-		await http.run(mockedSocket as any, 'measurement', 'test', options);
-
-		stream.emit('response', events.response);
-		stream.emit('end');
-
-		expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
-		expect(mockedSocket.emit.lastCall.args[1]).to.deep.equal(expectedResult);
-	});
-
-	it('should emit error', async () => {
-		const options = {
-			type: 'http',
-			target: 'google.com',
-			query: {
-				method: 'get',
-				protocol: 'http',
-				path: '/',
-			},
-		};
-
-		const events = {
-			response: {
-				socket: {},
-				timings: {
-					phases: {
+			const expectedResult = {
+				measurementId: 'measurement',
+				result: {
+					headers: {},
+					rawHeaders: '',
+					rawBody: '',
+					timings: {
 						download: 10,
 						total: 11,
 					},
+					tls: {},
+					rawOutput: 'ENODATA google.com - abc',
+					statusCode: 0,
 				},
-			},
-			error: new HttpError('ENODATA google.com', 'abc'),
-		};
+				testId: 'test',
+			};
 
-		const response = {
-			...events.response,
-		};
+			const stream = new Stream(response);
 
-		const expectedResult = {
-			measurementId: 'measurement',
-			result: {
-				headers: {},
-				rawHeaders: '',
-				rawBody: '',
-				timings: {
-					download: 10,
-					total: 11,
-				},
-				tls: {},
-				rawOutput: 'ENODATA google.com - abc',
-				statusCode: 0,
-			},
-			testId: 'test',
-		};
+			const mockHttpCmd = (): Request => stream as never;
 
-		const stream = new Stream(response);
+			const http = new HttpCommand(mockHttpCmd);
+			const cmd = http.run(mockedSocket as any, 'measurement', 'test', options);
 
-		const httpCmd = (): Request => stream as never;
+			stream.emit('error', events.error);
 
-		const http = new HttpCommand(httpCmd);
-		await http.run(mockedSocket as any, 'measurement', 'test', options);
+			await cmd;
 
-		stream.emit('error', events.error);
-
-		expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
-		expect(mockedSocket.emit.lastCall.args[1]).to.deep.equal(expectedResult);
+			expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
+			expect(mockedSocket.emit.lastCall.args[1]).to.deep.equal(expectedResult);
+		});
 	});
 });


### PR DESCRIPTION
- [x] HTTP errors should be handled (as 2XX would)
- [x] target has to start with a slash (correct if its not)
- [x] tests

fixes https://github.com/jsdelivr/globalping/issues/149