### PR TITLE
ref: response schemas

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -25,7 +25,7 @@ type DnsOptions = {
 	};
 };
 
-const isTrace = (output: any): output is DnsParseResponseTrace => Array.isArray((output as DnsParseResponseTrace).result);
+const isTrace = (output: any): output is DnsParseResponseTrace => Array.isArray((output as DnsParseResponseTrace).hops);
 
 const allowedTypes = ['A', 'AAAA', 'ANY', 'CNAME', 'DNSKEY', 'DS', 'MX', 'NS', 'NSEC', 'PTR', 'RRSIG', 'SOA', 'TXT', 'SRV'];
 const allowedProtocols = ['UDP', 'TCP'];
@@ -145,7 +145,7 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 		let privateResults = [];
 
 		if (isTrace(result)) {
-			privateResults = result.result
+			privateResults = result.hops
 				.flatMap((result: DnsParseLoopResponse) => result.answer)
 				.filter((answer: unknown) => isDnsSection(answer) ? isIpPrivate(answer.value as string) : false);
 		} else {

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -146,10 +146,10 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 
 		if (isTrace(result)) {
 			privateResults = result.hops
-				.flatMap((result: DnsParseLoopResponse) => result.answer)
+				.flatMap((result: DnsParseLoopResponse) => result.answers)
 				.filter((answer: unknown) => isDnsSection(answer) ? isIpPrivate(answer.value as string) : false);
 		} else {
-			privateResults = result.answer
+			privateResults = result.answers
 				.filter((answer: unknown) => isDnsSection(answer) ? isIpPrivate(answer.value as string) : false);
 		}
 

--- a/src/command/handlers/dig/classic.ts
+++ b/src/command/handlers/dig/classic.ts
@@ -40,20 +40,20 @@ export const ClassicDigParser = {
 		const result: DnsParseLoopResponse = {
 			header: [],
 			answer: [],
-			server: '',
-			time: 0,
+			resolver: '',
+			timings: {total: 0},
 		};
 
 		let section = 'header';
 		for (const line of lines) {
 			const time = ClassicDigParser.getQueryTime(line);
 			if (time !== undefined) {
-				result.time = time;
+				result.timings.total = time;
 			}
 
 			const serverMatch = ClassicDigParser.getResolverServer(line);
 			if (serverMatch) {
-				result.server = serverMatch;
+				result.resolver = serverMatch;
 			}
 
 			let sectionChanged = false;
@@ -88,8 +88,8 @@ export const ClassicDigParser = {
 
 		return {
 			answer: result.answer,
-			server: result.server,
-			time: result.time,
+			resolver: result.resolver,
+			timings: result.timings,
 		};
 	},
 

--- a/src/command/handlers/dig/classic.ts
+++ b/src/command/handlers/dig/classic.ts
@@ -39,7 +39,7 @@ export const ClassicDigParser = {
 	parseLoop(lines: string[]): DnsParseLoopResponse {
 		const result: DnsParseLoopResponse = {
 			header: [],
-			answer: [],
+			answers: [],
 			resolver: '',
 			timings: {total: 0},
 		};
@@ -79,15 +79,15 @@ export const ClassicDigParser = {
 			if (!sectionChanged && line) {
 				if (section === 'header') {
 					result[section]!.push(line);
-				} else {
+				} else if (section === 'answer') {
 					const sectionResult = ClassicDigParser.parseSection(line.split(/\s+/g), section);
-					(result[section] as DnsSection[]).push(sectionResult);
+					(result.answers).push(sectionResult);
 				}
 			}
 		}
 
 		return {
-			answer: result.answer,
+			answers: result.answers,
 			resolver: result.resolver,
 			timings: result.timings,
 		};

--- a/src/command/handlers/dig/shared.ts
+++ b/src/command/handlers/dig/shared.ts
@@ -15,7 +15,7 @@ export type DnsParseLoopResponse = {
 	[key: string]: any;
 	question?: any[];
 	header?: any[];
-	answer: DnsSection[];
+	answers: DnsSection[];
 	timings: {total: number};
 	resolver: string;
 };

--- a/src/command/handlers/dig/shared.ts
+++ b/src/command/handlers/dig/shared.ts
@@ -4,7 +4,7 @@ export type DnsValueType = string | {
 };
 
 export type DnsSection = Record<string, unknown> | {
-	domain: string;
+	name: string;
 	type: string;
 	ttl: number;
 	class: string;
@@ -16,8 +16,8 @@ export type DnsParseLoopResponse = {
 	question?: any[];
 	header?: any[];
 	answer: DnsSection[];
-	time: number;
-	server: string;
+	timings: {total: number};
+	resolver: string;
 };
 
 export const isDnsSection = (output: any): output is DnsSection => typeof (output as DnsSection) !== 'undefined';
@@ -31,9 +31,9 @@ export const NEW_LINE_REG_EXP = /\r?\n/;
 export const SharedDigParser = {
 	parseSection(values: string[]): DnsSection {
 		return {
-			domain: values[0],
+			name: values[0],
 			type: values[3],
-			ttl: values[1],
+			ttl: Number(values[1] ?? ''),
 			class: values[2],
 			value: SharedDigParser.parseValue(values),
 		};

--- a/src/command/handlers/dig/trace.ts
+++ b/src/command/handlers/dig/trace.ts
@@ -6,7 +6,7 @@ import {
 } from './shared.js';
 
 export type DnsParseResponse = {
-	result: DnsParseLoopResponse[];
+	hops: DnsParseLoopResponse[];
 	rawOutput: string;
 };
 
@@ -31,7 +31,7 @@ export const TraceDigParser = {
 		}
 
 		return {
-			result: TraceDigParser.parseLoop(lines.slice(2)),
+			hops: TraceDigParser.parseLoop(lines.slice(2)),
 			rawOutput,
 		};
 	},
@@ -39,15 +39,15 @@ export const TraceDigParser = {
 	parseLoop(lines: string[]): DnsParseLoopResponse[] {
 		const groups: Array<{
 			answer: DnsSection[];
-			time: number;
-			server: string;
+			timings: {total: number};
+			resolver: string;
 		}> = [];
 
 		const pushNewHop = () => {
 			groups.push({
 				answer: [],
-				time: 0,
-				server: '',
+				timings: {total: 0},
+				resolver: '',
 			});
 		};
 
@@ -66,8 +66,8 @@ export const TraceDigParser = {
 				const resolver = RESOLVER_REG_EXP.exec(line);
 				const queryTime = QUERY_TIME_REG_EXP.exec(line);
 
-				groups[groupIndex]!.time = queryTime ? Number(queryTime[1]) : 0;
-				groups[groupIndex]!.server = resolver ? String(resolver[1]) : '';
+				groups[groupIndex]!.timings.total = queryTime ? Number(queryTime[1]) : 0;
+				groups[groupIndex]!.resolver = resolver ? String(resolver[1]) : '';
 
 				continue;
 			}

--- a/src/command/handlers/dig/trace.ts
+++ b/src/command/handlers/dig/trace.ts
@@ -38,14 +38,14 @@ export const TraceDigParser = {
 
 	parseLoop(lines: string[]): DnsParseLoopResponse[] {
 		const groups: Array<{
-			answer: DnsSection[];
+			answers: DnsSection[];
 			timings: {total: number};
 			resolver: string;
 		}> = [];
 
 		const pushNewHop = () => {
 			groups.push({
-				answer: [],
+				answers: [],
 				timings: {total: 0},
 				resolver: '',
 			});
@@ -73,10 +73,12 @@ export const TraceDigParser = {
 			}
 
 			const answer = SharedDigParser.parseSection(line.split(/\s+/g));
-			groups[groupIndex]!.answer.push(answer);
+			groups[groupIndex]!.answers.push(answer);
 		}
 
-		return groups.map(item => ({...item, answer: item.answer}));
+		return groups.map(item => ({
+			...item, answers: item.answers,
+		}));
 	},
 };
 

--- a/src/command/handlers/mtr/types.ts
+++ b/src/command/handlers/mtr/types.ts
@@ -1,6 +1,7 @@
 export type HopTimesType = {
-	seq: string;
-	time?: number;
+	seq?: string;
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	rtt: number | null;
 };
 
 export type HopStatsType = {
@@ -17,15 +18,17 @@ export type HopStatsType = {
 };
 
 export type HopType = {
-	asn?: string;
-	host?: string;
-	resolvedHost?: string;
+	asn: number[];
+	resolvedAddress?: string;
+	resolvedHostname?: string;
 	stats: HopStatsType;
-	times: HopTimesType[];
+	timings: HopTimesType[];
 	duplicate?: boolean;
 };
 
 export type ResultType = {
+	resolvedAddress?: string;
+	resolvedHostname?: string;
 	hops: HopType[];
 	data: string[];
 	rawOutput: string;

--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -222,8 +222,10 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 			result.tls = {
 				authorized: rSocket.authorized,
 				...(rSocket.authorizationError ? {error: rSocket.authorizationError} : {}),
-				createdAt: (new Date(cert.valid_from)).toISOString(),
-				expireAt: (new Date(cert.valid_to)).toISOString(),
+				...(cert.valid_from && cert.valid_to ? {
+					createdAt: (new Date(cert.valid_from)).toISOString(),
+					expireAt: (new Date(cert.valid_to)).toISOString(),
+				} : {}),
 				issuer: {...cert.issuer},
 				subject: {
 					...cert.subject,

--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -28,6 +28,7 @@ export type Timings = {
 };
 
 const getInitialResult = () => ({
+	resolvedAddress: '',
 	tls: {},
 	error: '',
 	headers: {},
@@ -106,6 +107,8 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 		let result = getInitialResult();
 
 		const respond = (resolve: () => void) => {
+			result.resolvedAddress = stream.ip ?? '';
+
 			const timings = (stream.timings ?? {}) as Timings;
 			if (!timings['end']) {
 				timings['end'] = Date.now();
@@ -125,6 +128,7 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 				testId,
 				measurementId,
 				result: {
+					resolvedAddress: result.resolvedAddress,
 					headers: result.headers,
 					rawHeaders: result.rawHeaders,
 					rawBody: result.rawBody,
@@ -218,8 +222,8 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 			result.tls = {
 				authorized: rSocket.authorized,
 				...(rSocket.authorizationError ? {error: rSocket.authorizationError} : {}),
-				createdAt: cert.valid_from,
-				expireAt: cert.valid_to,
+				createdAt: (new Date(cert.valid_from)).toISOString(),
+				expireAt: (new Date(cert.valid_to)).toISOString(),
 				issuer: {...cert.issuer},
 				subject: {
 					...cert.subject,

--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -224,7 +224,7 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 				...(rSocket.authorizationError ? {error: rSocket.authorizationError} : {}),
 				...(cert.valid_from && cert.valid_to ? {
 					createdAt: (new Date(cert.valid_from)).toISOString(),
-					expireAt: (new Date(cert.valid_to)).toISOString(),
+					expiresAt: (new Date(cert.valid_to)).toISOString(),
 				} : {}),
 				issuer: {...cert.issuer},
 				subject: {

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -125,6 +125,7 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 	private parse(rawOutput: string): {
 		rawOutput: string;
 		resolvedAddress?: string;
+		resolvedHostname?: string;
 		hops?: ParsedLine[];
 	} {
 		const lines = rawOutput.split('\n');
@@ -144,9 +145,11 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 		}
 
 		const hops = lines.slice(1).map(l => this.parseLine(l));
+		const hostname = hops[hops.length - 1]?.resolvedHostname;
 
 		return {
 			resolvedAddress: String(header.resolvedAddress),
+			resolvedHostname: String(hostname),
 			hops,
 			rawOutput,
 		};

--- a/test/mocks/dns-success-linux.json
+++ b/test/mocks/dns-success-linux.json
@@ -2,7 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
-		"answer": [
+		"answers": [
 			{
 				"name": "google.com.",
 				"type": "TXT",

--- a/test/mocks/dns-success-linux.json
+++ b/test/mocks/dns-success-linux.json
@@ -4,71 +4,71 @@
   "result": {
 		"answer": [
 			{
-				"domain": "google.com.",
+				"name": "google.com.",
 				"type": "TXT",
-				"ttl": "3600",
+				"ttl": 3600,
 				"class": "IN",
 				"value": "\"v=spf1 include:_spf.google.com ~all\""
 			},
 			{
-				"domain": "google.com.",
+				"name": "google.com.",
 				"type": "TXT",
-				"ttl": "3600",
+				"ttl": 3600,
 				"class": "IN",
 				"value": "\"facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95\""
 			},
 			{
-				"domain": "google.com.",
+				"name": "google.com.",
 				"type": "TXT",
-				"ttl": "3600",
+				"ttl": 3600,
 				"class": "IN",
 				"value": "\"apple-domain-verification=30afIBcvSuDV2PLX\""
 			},
 			{
-				"domain": "google.com.",
+				"name": "google.com.",
 				"type": "TXT",
-				"ttl": "3600",
+				"ttl": 3600,
 				"class": "IN",
 				"value": "\"docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e\""
 			},
 			{
-				"domain": "google.com.",
+				"name": "google.com.",
 				"type": "TXT",
-				"ttl": "3600",
+				"ttl": 3600,
 				"class": "IN",
 				"value": "\"docusign=1b0a6754-49b1-4db5-8540-d2c12664b289\""
 			},
 			{
-				"domain": "google.com.",
+				"name": "google.com.",
 				"type": "TXT",
-				"ttl": "3600",
+				"ttl": 3600,
 				"class": "IN",
 				"value": "\"MS=E4A68B9AB2BB9670BCE15412F62916164C0B20BB\""
 			},
 			{
-				"domain": "google.com.",
+				"name": "google.com.",
 				"type": "TXT",
-				"ttl": "3600",
+				"ttl": 3600,
 				"class": "IN",
 				"value": "\"google-site-verification=TV9-DBe4R80X4v0M4U_bd_J9cpOJM0nikft0jAgjmsQ\""
 			},
 			{
-				"domain": "google.com.",
+				"name": "google.com.",
 				"type": "TXT",
-				"ttl": "3600",
+				"ttl": 3600,
 				"class": "IN",
 				"value": "\"google-site-verification=wD8N7i1JTNTkezJ49swvWW48f8_9xveREV4oB-0Hf5o\""
 			},
 			{
-				"domain": "google.com.",
+				"name": "google.com.",
 				"type": "TXT",
-				"ttl": "3600",
+				"ttl": 3600,
 				"class": "IN",
 				"value": "\"globalsign-smime-dv=CDYX+XFHUw2wml6/Gb8+59BsH31KzUr6c1l2BPvqKX8=\""
 			}
 		],
-		"time": 0,
-		"server": "192.168.0.49",
+		"timings": { "total": 0 },
+		"resolver": "192.168.0.49",
 		"rawOutput": ";; Truncated, retrying in TCP mode.\n\n; <<>> DiG 9.16.1-Ubuntu <<>> google.com -t TXT -p 53 -4 +timeout=3 +tries=2 +nocookie\n;; global options: +cmd\n;; Got answer:\n;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 29356\n;; flags: qr rd ra; QUERY: 1, ANSWER: 9, AUTHORITY: 0, ADDITIONAL: 0\n\n;; QUESTION SECTION:\n;google.com.\t\t\tIN\tTXT\n\n;; ANSWER SECTION:\ngoogle.com.\t\t3600\tIN\tTXT\t\"v=spf1 include:_spf.google.com ~all\"\ngoogle.com.\t\t3600\tIN\tTXT\t\"facebook-domain-verification=22rm551cu4k0ab0bxsw536tlds4h95\"\ngoogle.com.\t\t3600\tIN\tTXT\t\"apple-domain-verification=30afIBcvSuDV2PLX\"\ngoogle.com.\t\t3600\tIN\tTXT\t\"docusign=05958488-4752-4ef2-95eb-aa7ba8a3bd0e\"\ngoogle.com.\t\t3600\tIN\tTXT\t\"docusign=1b0a6754-49b1-4db5-8540-d2c12664b289\"\ngoogle.com.\t\t3600\tIN\tTXT\t\"MS=E4A68B9AB2BB9670BCE15412F62916164C0B20BB\"\ngoogle.com.\t\t3600\tIN\tTXT\t\"google-site-verification=TV9-DBe4R80X4v0M4U_bd_J9cpOJM0nikft0jAgjmsQ\"\ngoogle.com.\t\t3600\tIN\tTXT\t\"google-site-verification=wD8N7i1JTNTkezJ49swvWW48f8_9xveREV4oB-0Hf5o\"\ngoogle.com.\t\t3600\tIN\tTXT\t\"globalsign-smime-dv=CDYX+XFHUw2wml6/Gb8+59BsH31KzUr6c1l2BPvqKX8=\"\n\n;; Query time: 0 msec\n;; SERVER: 192.168.0.49#53(192.168.0.49)\n;; WHEN: Mon Apr 04 12:25:44 UTC 2022\n;; MSG SIZE  rcvd: 614\n"
 	}
 }

--- a/test/mocks/dns-trace-success.json
+++ b/test/mocks/dns-trace-success.json
@@ -3,322 +3,322 @@
     "measurementId": "measurement",
     "result":
     {
-        "result":
+        "hops":
         [
             {
                 "answer":
                 [
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "j.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "c.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "g.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "b.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "i.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "a.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "e.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "l.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "k.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "f.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "m.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "d.root-servers.net."
                     },
                     {
-                        "domain": ".",
+                        "name": ".",
                         "type": "NS",
-                        "ttl": "6593",
+                        "ttl": 6593,
                         "class": "IN",
                         "value": "h.root-servers.net."
                     }
                 ],
-                "time": 4,
-                "server": "127.0.0.53"
+                "timings": { "total": 4 },
+                "resolver": "127.0.0.53"
             },
             {
                 "answer":
                 [
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "a.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "b.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "c.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "d.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "e.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "f.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "g.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "h.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "i.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "j.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "k.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "l.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "m.gtld-servers.net."
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "DS",
-                        "ttl": "86400",
+                        "ttl": 86400,
                         "class": "IN",
                         "value": "8BD973EE"
                     },
                     {
-                        "domain": "net.",
+                        "name": "net.",
                         "type": "RRSIG",
-                        "ttl": "86400",
+                        "ttl": 86400,
                         "class": "IN",
                         "value": "nStNJg=="
                     }
                 ],
-                "time": 24,
-                "server": "d.root-servers.net"
+                "timings": { "total": 24 },
+                "resolver": "d.root-servers.net"
             },
             {
                 "answer":
                 [
                     {
-                        "domain": "jsdelivr.net.",
+                        "name": "jsdelivr.net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "dns1.p03.nsone.net."
                     },
                     {
-                        "domain": "jsdelivr.net.",
+                        "name": "jsdelivr.net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "dns2.p03.nsone.net."
                     },
                     {
-                        "domain": "jsdelivr.net.",
+                        "name": "jsdelivr.net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "dns3.p03.nsone.net."
                     },
                     {
-                        "domain": "jsdelivr.net.",
+                        "name": "jsdelivr.net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "dns4.p03.nsone.net."
                     },
                     {
-                        "domain": "jsdelivr.net.",
+                        "name": "jsdelivr.net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "gns1.cloudns.net."
                     },
                     {
-                        "domain": "jsdelivr.net.",
+                        "name": "jsdelivr.net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "gns2.cloudns.net."
                     },
                     {
-                        "domain": "jsdelivr.net.",
+                        "name": "jsdelivr.net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "gns3.cloudns.net."
                     },
                     {
-                        "domain": "jsdelivr.net.",
+                        "name": "jsdelivr.net.",
                         "type": "NS",
-                        "ttl": "172800",
+                        "ttl": 172800,
                         "class": "IN",
                         "value": "gns4.cloudns.net."
                     },
                     {
-                        "domain": "A1RT98BS5QGC9NFI51S9HCI47ULJG6JH.net.",
+                        "name": "A1RT98BS5QGC9NFI51S9HCI47ULJG6JH.net.",
                         "type": "NSEC3",
-                        "ttl": "86400",
+                        "ttl": 86400,
                         "class": "IN",
                         "value": "NSEC3PARAM"
                     },
                     {
-                        "domain": "A1RT98BS5QGC9NFI51S9HCI47ULJG6JH.net.",
+                        "name": "A1RT98BS5QGC9NFI51S9HCI47ULJG6JH.net.",
                         "type": "RRSIG",
-                        "ttl": "86400",
+                        "ttl": 86400,
                         "class": "IN",
                         "value": "QKqFhOv3D/NZtRua5mWeuy78rB3MIZQmGQ7rwapaz4h4eg=="
                     },
                     {
-                        "domain": "GBMGFDMMHIENHS2RNSDAQ541H88GB5IO.net.",
+                        "name": "GBMGFDMMHIENHS2RNSDAQ541H88GB5IO.net.",
                         "type": "NSEC3",
-                        "ttl": "86400",
+                        "ttl": 86400,
                         "class": "IN",
                         "value": "RRSIG"
                     },
                     {
-                        "domain": "GBMGFDMMHIENHS2RNSDAQ541H88GB5IO.net.",
+                        "name": "GBMGFDMMHIENHS2RNSDAQ541H88GB5IO.net.",
                         "type": "RRSIG",
-                        "ttl": "86400",
+                        "ttl": 86400,
                         "class": "IN",
                         "value": "NO9LoUolBGhvxHSQfhwCyAi0slPURsAkC4DBUS1WrpipCQ=="
                     }
                 ],
-                "time": 32,
-                "server": "c.gtld-servers.net"
+                "timings": { "total": 32 },
+                "resolver": "c.gtld-servers.net"
             },
             {
                 "answer":
                 [
                     {
-                        "domain": "cdn.jsdelivr.net.",
+                        "name": "cdn.jsdelivr.net.",
                         "type": "CNAME",
-                        "ttl": "900",
+                        "ttl": 900,
                         "class": "IN",
                         "value": "jsdelivr.map.fastly.net."
                     }
                 ],
-                "time": 28,
-                "server": "gns3.cloudns.net"
+                "timings": { "total": 28 },
+                "resolver": "gns3.cloudns.net"
             }
         ],
         "rawOutput": "; <<>> DiG 9.18.1-1ubuntu1-Ubuntu <<>> +trace +nocookie +tries +timeout cdn.jsdelivr.net\n;; global options: +cmd\n.\t\t\t6593\tIN\tNS\tj.root-servers.net.\n.\t\t\t6593\tIN\tNS\tc.root-servers.net.\n.\t\t\t6593\tIN\tNS\tg.root-servers.net.\n.\t\t\t6593\tIN\tNS\tb.root-servers.net.\n.\t\t\t6593\tIN\tNS\ti.root-servers.net.\n.\t\t\t6593\tIN\tNS\ta.root-servers.net.\n.\t\t\t6593\tIN\tNS\te.root-servers.net.\n.\t\t\t6593\tIN\tNS\tl.root-servers.net.\n.\t\t\t6593\tIN\tNS\tk.root-servers.net.\n.\t\t\t6593\tIN\tNS\tf.root-servers.net.\n.\t\t\t6593\tIN\tNS\tm.root-servers.net.\n.\t\t\t6593\tIN\tNS\td.root-servers.net.\n.\t\t\t6593\tIN\tNS\th.root-servers.net.\n;; Received 811 bytes from 127.0.0.53#53(127.0.0.53) in 4 ms\n\nnet.\t\t\t172800\tIN\tNS\ta.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\tb.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\tc.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\td.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\te.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\tf.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\tg.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\th.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\ti.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\tj.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\tk.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\tl.gtld-servers.net.\nnet.\t\t\t172800\tIN\tNS\tm.gtld-servers.net.\nnet.\t\t\t86400\tIN\tDS\t35886 8 2 7862B27F5F516EBE19680444D4CE5E762981931842C465F00236401D 8BD973EE\nnet.\t\t\t86400\tIN\tRRSIG\tDS 8 1 86400 20220509170000 20220426160000 47671 . IbbmgURsOFU02lEF33VZIt90+xd+DSAy6n+LowQlVMbxAxB6BsF5nNi1 n0Xsfixgxk06JOsQOLeMnTSX6xGZ5baCHa8pWGlS2CZ3wpmWt9Fg5Y/r Vqpneq9sBXuvcyLZ4OOzxqY8Xvqnj5EBqx2wegOxqOzbw4I2MLPeFWS4 hRvHcodnVkAHaWbDWLi3olY+8nIdWMLRdMxA1VkzliQn0MOPNn6mhKeG HTh3uOo7FSm+adbefRhC6X8QDoSFQ6VKYhd3mVJ7HGJ2JsvpVsJlG5Ff WNBztAw7W5Tg9aIVxPwfl3tNvlkpyvDqgurJLXVqmB7F+t3f3+8QKDMb nStNJg==\n;; Received 1173 bytes from 199.7.91.13#53(d.root-servers.net) in 24 ms\n\njsdelivr.net.\t\t172800\tIN\tNS\tdns1.p03.nsone.net.\njsdelivr.net.\t\t172800\tIN\tNS\tdns2.p03.nsone.net.\njsdelivr.net.\t\t172800\tIN\tNS\tdns3.p03.nsone.net.\njsdelivr.net.\t\t172800\tIN\tNS\tdns4.p03.nsone.net.\njsdelivr.net.\t\t172800\tIN\tNS\tgns1.cloudns.net.\njsdelivr.net.\t\t172800\tIN\tNS\tgns2.cloudns.net.\njsdelivr.net.\t\t172800\tIN\tNS\tgns3.cloudns.net.\njsdelivr.net.\t\t172800\tIN\tNS\tgns4.cloudns.net.\nA1RT98BS5QGC9NFI51S9HCI47ULJG6JH.net. 86400 IN NSEC3 1 1 0 - A1RTLNPGULOGN7B9A62SHJE1U3TTP8DR NS SOA RRSIG DNSKEY NSEC3PARAM\nA1RT98BS5QGC9NFI51S9HCI47ULJG6JH.net. 86400 IN RRSIG NSEC3 8 2 86400 20220503055829 20220426044829 45728 net. kqtegTsTwSJ9OJ/4UpoKnOzaSfaEaSxd03SERi2nhwhL1Dd/xjXF+Oy+ gB2NxI8IHBdT0Za1PadKRYefjjI+phvYB2Z2s7LqLE5iLju+2R6mVMQu TfkTO8GJWxBDMcXdcX2cjTxSan7y8m4kbzeGvqFHwiWtodDnT2lFQBvg QKqFhOv3D/NZtRua5mWeuy78rB3MIZQmGQ7rwapaz4h4eg==\nGBMGFDMMHIENHS2RNSDAQ541H88GB5IO.net. 86400 IN NSEC3 1 1 0 - GBMKRB78QIII3C3NIFGFSK27G1IBHMM0 NS DS RRSIG\nGBMGFDMMHIENHS2RNSDAQ541H88GB5IO.net. 86400 IN RRSIG NSEC3 8 2 86400 20220430055643 20220423044643 45728 net. JIFFMnHeaG97gcZYao5JGWkTJ4zGKDAKrfLOi9KrKVmBroFmnjfOytBo NgTxIl17GlLW2kaq1doKHpDHUu8y4u/56OdJmeBgL+OYqGbQjmICztpK dU+p9eoXUPLMkDFTqrwFhN1dm51Q9sle4MiDHMeLHBrs76jlpBcR+PQn NO9LoUolBGhvxHSQfhwCyAi0slPURsAkC4DBUS1WrpipCQ==\n;; Received 1116 bytes from 192.26.92.30#53(c.gtld-servers.net) in 32 ms\n\ncdn.jsdelivr.net.\t900\tIN\tCNAME\tjsdelivr.map.fastly.net.\n;; Received 79 bytes from 185.136.98.122#53(gns3.cloudns.net) in 28 ms\n"

--- a/test/mocks/dns-trace-success.json
+++ b/test/mocks/dns-trace-success.json
@@ -6,7 +6,7 @@
         "hops":
         [
             {
-                "answer":
+                "answers":
                 [
                     {
                         "name": ".",
@@ -104,7 +104,7 @@
                 "resolver": "127.0.0.53"
             },
             {
-                "answer":
+                "answers":
                 [
                     {
                         "name": "net.",
@@ -216,7 +216,7 @@
                 "resolver": "d.root-servers.net"
             },
             {
-                "answer":
+                "answers":
                 [
                     {
                         "name": "jsdelivr.net.",
@@ -307,7 +307,7 @@
                 "resolver": "c.gtld-servers.net"
             },
             {
-                "answer":
+                "answers":
                 [
                     {
                         "name": "cdn.jsdelivr.net.",

--- a/test/mocks/mtr-fail-private-ip.json
+++ b/test/mocks/mtr-fail-private-ip.json
@@ -2,6 +2,8 @@
     "testId": "test",
     "measurementId": "measurement",
     "result": {
+      "resolvedAddress": "",
+      "resolvedHostname": "",
       "hops": [],
       "data": [],
       "rawOutput": "Private IP ranges are not allowed"

--- a/test/mocks/mtr-success-raw-helper-final.json
+++ b/test/mocks/mtr-success-raw-helper-final.json
@@ -18,22 +18,18 @@
                     "jMax": 2.3,
                     "jAvg": 2.3
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33000",
-                        "time": 2.27
+                        "rtt": 2.27
                     },
-                    {
-                        "seq": "33010"
-                    },
-                    {
-                        "seq": "33019"
-                    }
+                    {"rtt": null},
+                    {"rtt": null}
                 ],
-                "host": "192.168.0.1",
+                "asn": [],
+                "resolvedAddress": "192.168.0.1",
                 "duplicate": false,
-                "resolvedHost": "192.168.0.1"
+                "resolvedHostname": "192.168.0.1"
             },
             {
                 "stats":
@@ -49,18 +45,13 @@
                     "jMax": 0,
                     "jAvg": 0
                 },
-                "times":
+                "timings":
                 [
-                    {
-                        "seq": "33001"
-                    },
-                    {
-                        "seq": "33011"
-                    },
-                    {
-                        "seq": "33020"
-                    }
-                ]
+                    {"rtt": null},
+                    {"rtt": null},
+                    {"rtt": null}
+                ],
+                "asn": []
             },
             {
                 "stats":
@@ -76,24 +67,22 @@
                     "jMax": 11.3,
                     "jAvg": 6.2
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33002",
-                        "time": 10.394
+                        "rtt": 10.394
                     },
                     {
-                        "seq": "33012",
-                        "time": 9.222
+                        "rtt": 9.222
                     },
                     {
-                        "seq": "33021",
-                        "time": 11.276
+                        "rtt": 11.276
                     }
                 ],
-                "host": "62.252.67.181",
+                "asn": [],
+                "resolvedAddress": "62.252.67.181",
                 "duplicate": false,
-                "resolvedHost": "62.252.67.181"
+                "resolvedHostname": "62.252.67.181"
             },
             {
                 "stats":
@@ -109,18 +98,13 @@
                     "jMax": 0,
                     "jAvg": 0
                 },
-                "times":
+                "timings":
                 [
-                    {
-                        "seq": "33003"
-                    },
-                    {
-                        "seq": "33013"
-                    },
-                    {
-                        "seq": "33022"
-                    }
-                ]
+                    {"rtt": null},
+                    {"rtt": null},
+                    {"rtt": null}
+                ],
+                "asn": []
             },
             {
                 "stats":
@@ -136,24 +120,22 @@
                     "jMax": 11.6,
                     "jAvg": 6.5
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33004",
-                        "time": 12.049
+                        "rtt": 12.049
                     },
                     {
-                        "seq": "33014",
-                        "time": 10.779
+                        "rtt": 10.779
                     },
                     {
-                        "seq": "33023",
-                        "time": 11.638
+                        "rtt": 11.638
                     }
                 ],
-                "host": "62.254.59.130",
+                "asn": [],
+                "resolvedAddress": "62.254.59.130",
                 "duplicate": false,
-                "resolvedHost": "62.254.59.130"
+                "resolvedHostname": "62.254.59.130"
             },
             {
                 "stats":
@@ -169,24 +151,22 @@
                     "jMax": 11.4,
                     "jAvg": 6
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33005",
-                        "time": 10.949
+                        "rtt": 10.949
                     },
                     {
-                        "seq": "33015",
-                        "time": 11.595
+                        "rtt": 11.595
                     },
                     {
-                        "seq": "33024",
-                        "time": 11.393
+                        "rtt": 11.393
                     }
                 ],
-                "host": "142.250.160.116",
+                "asn": [],
+                "resolvedAddress": "142.250.160.116",
                 "duplicate": false,
-                "resolvedHost": "142.250.160.116"
+                "resolvedHostname": "142.250.160.116"
             },
             {
                 "stats":
@@ -202,24 +182,22 @@
                     "jMax": 15.1,
                     "jAvg": 8
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33006",
-                        "time": 15.835
+                        "rtt": 15.835
                     },
                     {
-                        "seq": "33016",
-                        "time": 16.612
+                        "rtt": 16.612
                     },
                     {
-                        "seq": "33025",
-                        "time": 15.144
+                        "rtt": 15.144
                     }
                 ],
-                "host": "216.239.41.193",
+                "asn": [],
+                "resolvedAddress": "216.239.41.193",
                 "duplicate": false,
-                "resolvedHost": "216.239.41.193"
+                "resolvedHostname": "216.239.41.193"
             },
             {
                 "stats":
@@ -235,24 +213,22 @@
                     "jMax": 12.9,
                     "jAvg": 8.2
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33007",
-                        "time": 15.666
+                        "rtt": 15.666
                     },
                     {
-                        "seq": "33017",
-                        "time": 12.228
+                        "rtt": 12.228
                     },
                     {
-                        "seq": "33026",
-                        "time": 12.872
+                        "rtt": 12.872
                     }
                 ],
-                "host": "142.251.54.27",
+                "asn": [],
+                "resolvedAddress": "142.251.54.27",
                 "duplicate": false,
-                "resolvedHost": "142.251.54.27"
+                "resolvedHostname": "142.251.54.27"
             },
             {
                 "stats":
@@ -268,24 +244,22 @@
                     "jMax": 11.2,
                     "jAvg": 6.4
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33008",
-                        "time": 11.767
+                        "rtt": 11.767
                     },
                     {
-                        "seq": "33018",
-                        "time": 10.092
+                        "rtt": 10.092
                     },
                     {
-                        "seq": "33027",
-                        "time": 11.215
+                        "rtt": 11.215
                     }
                 ],
-                "host": "142.250.179.238",
+                "asn": [],
+                "resolvedAddress": "142.250.179.238",
                 "duplicate": false,
-                "resolvedHost": "lhr25s31-in-f14.1e100.net"
+                "resolvedHostname": "lhr25s31-in-f14.1e100.net"
             },
             {
                 "stats":
@@ -301,19 +275,19 @@
                     "jMax": 11.4,
                     "jAvg": 11.4
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33009",
-                        "time": 11.352
+                        "rtt": 11.352
                     }
                 ],
-                "host": "142.250.179.238",
+                "asn": [],
+                "resolvedAddress": "142.250.179.238",
                 "duplicate": true,
-                "resolvedHost": "lhr25s31-in-f14.1e100.net"
+                "resolvedHostname": "lhr25s31-in-f14.1e100.net"
             }
         ],
-        "rawOutput": "Host                                                  Loss% Drop Rcv  Avg  StDev  Javg \n 1. AS??? _gateway (192.168.0.1)                        66.7%    2   1  2.3    0.0   2.3\n 2. AS??? (waiting for reply)                         \n 3. AS??? 62.252.67.181 (62.252.67.181)                  0.0%    0   3 10.3    0.8   6.2\n 4. AS??? (waiting for reply)                         \n 5. AS??? 62.254.59.130 (62.254.59.130)                  0.0%    0   3 11.5    0.5   6.5\n 6. AS??? 142.250.160.116 (142.250.160.116)              0.0%    0   3 11.3    0.3   6.0\n 7. AS??? 216.239.41.193 (216.239.41.193)                0.0%    0   3 15.9    0.6   8.0\n 8. AS??? 142.251.54.27 (142.251.54.27)                  0.0%    0   3 13.6    1.5   8.2\n 9. AS??? lhr25s31-in-f14.1e100.net (142.250.179.238)    0.0%    0   3 11.0    0.7   6.4\n",
+        "rawOutput": "Host                                                 Loss% Drop Rcv  Avg  StDev  Javg \n 1. AS??? _gateway (192.168.0.1)                        66.7%    2   1  2.3    0.0   2.3\n 2. AS??? (waiting for reply)                         \n 3. AS??? 62.252.67.181 (62.252.67.181)                  0.0%    0   3 10.3    0.8   6.2\n 4. AS??? (waiting for reply)                         \n 5. AS??? 62.254.59.130 (62.254.59.130)                  0.0%    0   3 11.5    0.5   6.5\n 6. AS??? 142.250.160.116 (142.250.160.116)              0.0%    0   3 11.3    0.3   6.0\n 7. AS??? 216.239.41.193 (216.239.41.193)                0.0%    0   3 15.9    0.6   8.0\n 8. AS??? 142.251.54.27 (142.251.54.27)                  0.0%    0   3 13.6    1.5   8.2\n 9. AS??? lhr25s31-in-f14.1e100.net (142.250.179.238)    0.0%    0   3 11.0    0.7   6.4\n",
         "data":
         [
             "x 0 33000",

--- a/test/mocks/mtr-success-raw-helper-progress.json
+++ b/test/mocks/mtr-success-raw-helper-progress.json
@@ -13,20 +13,23 @@
             "jMax": 3.7,
             "jAvg": 3.7
         },
-        "times":
+        "timings":
         [
             {
                 "seq": "33000",
-                "time": 3.734
+                "rtt": 3.734
             },
             {
-                "seq": "33011"
+                "seq": "33011",
+                "rtt": null
             },
             {
-                "seq": "33021"
+                "seq": "33021",
+                "rtt": null
             }
         ],
-        "host": "192.168.0.1",
+        "asn": [],
+        "resolvedAddress": "192.168.0.1",
         "duplicate": false
     },
     {
@@ -43,18 +46,22 @@
             "jMax": 0,
             "jAvg": 0
         },
-        "times":
+        "timings":
         [
             {
-                "seq": "33001"
+                "seq": "33001",
+                "rtt": null
             },
             {
-                "seq": "33012"
+                "seq": "33012",
+                "rtt": null
             },
             {
-                "seq": "33022"
+                "seq": "33022",
+                "rtt": null
             }
-        ]
+        ],
+        "asn": []
     },
     {
         "stats":
@@ -70,24 +77,25 @@
             "jMax": 10.9,
             "jAvg": 6.5
         },
-        "times":
+        "timings":
         [
             {
                 "seq": "33002",
-                "time": 12.102
+                "rtt": 12.102
             },
             {
                 "seq": "33013",
-                "time": 10.111
+                "rtt": 10.111
             },
             {
                 "seq": "33023",
-                "time": 10.933
+                "rtt": 10.933
             }
         ],
-        "host": "62.252.67.181",
+        "asn": [],
+        "resolvedAddress": "62.252.67.181",
         "duplicate": false,
-        "resolvedHost": "lutn-core-2a-xe-7114-0.network.virginmedia.net"
+        "resolvedHostname": "lutn-core-2a-xe-7114-0.network.virginmedia.net"
     },
     {
         "stats":
@@ -103,18 +111,22 @@
             "jMax": 0,
             "jAvg": 0
         },
-        "times":
+        "timings":
         [
             {
-                "seq": "33003"
+                "seq": "33003",
+                "rtt": null
             },
             {
-                "seq": "33014"
+                "seq": "33014",
+                "rtt": null
             },
             {
-                "seq": "33024"
+                "seq": "33024",
+                "rtt": null
             }
-        ]
+        ],
+        "asn": []
     },
     {
         "stats":
@@ -130,24 +142,25 @@
             "jMax": 12.9,
             "jAvg": 10.5
         },
-        "times":
+        "timings":
         [
             {
                 "seq": "33004",
-                "time": 19.959
+                "rtt": 19.959
             },
             {
                 "seq": "33015",
-                "time": 11.758
+                "rtt": 11.758
             },
             {
                 "seq": "33025",
-                "time": 12.855
+                "rtt": 12.855
             }
         ],
-        "host": "62.253.175.34",
+        "asn": [],
+        "resolvedAddress": "62.253.175.34",
         "duplicate": false,
-        "resolvedHost": "tele-ic-7-ae2-0.network.virginmedia.net"
+        "resolvedHostname": "tele-ic-7-ae2-0.network.virginmedia.net"
     },
     {
         "stats":
@@ -163,24 +176,25 @@
             "jMax": 10.6,
             "jAvg": 5.7
         },
-        "times":
+        "timings":
         [
             {
                 "seq": "33005",
-                "time": 12.821
+                "rtt": 12.821
             },
             {
                 "seq": "33016",
-                "time": 13.611
+                "rtt": 13.611
             },
             {
                 "seq": "33026",
-                "time": 10.649
+                "rtt": 10.649
             }
         ],
-        "host": "80.255.14.105",
+        "asn": [],
+        "resolvedAddress": "80.255.14.105",
         "duplicate": false,
-        "resolvedHost": "ae15-0.lon10.core-backbone.com"
+        "resolvedHostname": "ae15-0.lon10.core-backbone.com"
     },
     {
         "stats":
@@ -196,24 +210,25 @@
             "jMax": 28.4,
             "jAvg": 14.2
         },
-        "times":
+        "timings":
         [
             {
                 "seq": "33006",
-                "time": 28.627
+                "rtt": 28.627
             },
             {
                 "seq": "33017",
-                "time": 28.57
+                "rtt": 28.57
             },
             {
                 "seq": "33027",
-                "time": 28.409
+                "rtt": 28.409
             }
         ],
-        "host": "81.95.15.118",
+        "asn": [],
+        "resolvedAddress": "81.95.15.118",
         "duplicate": false,
-        "resolvedHost": "ae1-2053.prg10.core-backbone.com"
+        "resolvedHostname": "ae1-2053.prg10.core-backbone.com"
     },
     {
         "stats":
@@ -229,24 +244,25 @@
             "jMax": 33.4,
             "jAvg": 18.7
         },
-        "times":
+        "timings":
         [
             {
                 "seq": "33007",
-                "time": 33.591
+                "rtt": 33.591
             },
             {
                 "seq": "33018",
-                "time": 37.643
+                "rtt": 37.643
             },
             {
                 "seq": "33028",
-                "time": 33.42
+                "rtt": 33.42
             }
         ],
-        "host": "5.56.17.18",
+        "asn": [],
+        "resolvedAddress": "5.56.17.18",
         "duplicate": false,
-        "resolvedHost": "core-backbone.cdn77.com"
+        "resolvedHostname": "core-backbone.cdn77.com"
     },
     {
         "stats":
@@ -262,24 +278,25 @@
             "jMax": 28.4,
             "jAvg": 14.6
         },
-        "times":
+        "timings":
         [
             {
                 "seq": "33008",
-                "time": 28.482
+                "rtt": 28.482
             },
             {
                 "seq": "33019",
-                "time": 29.334
+                "rtt": 29.334
             },
             {
                 "seq": "33029",
-                "time": 28.426
+                "rtt": 28.426
             }
         ],
-        "host": "138.199.0.157",
+        "asn": [],
+        "resolvedAddress": "138.199.0.157",
         "duplicate": false,
-        "resolvedHost": "vl246.prg-ttc2-cdn77-dist-1.cdn77.com"
+        "resolvedHostname": "vl246.prg-ttc2-cdn77-dist-1.cdn77.com"
     },
     {
         "stats":
@@ -295,24 +312,25 @@
             "jMax": 31.3,
             "jAvg": 19.6
         },
-        "times":
+        "timings":
         [
             {
                 "seq": "33009",
-                "time": 28.557
+                "rtt": 28.557
             },
             {
                 "seq": "33020",
-                "time": 36.344
+                "rtt": 36.344
             },
             {
                 "seq": "33030",
-                "time": 31.345
+                "rtt": 31.345
             }
         ],
-        "host": "185.180.14.250",
+        "asn": [],
+        "resolvedAddress": "185.180.14.250",
         "duplicate": false,
-        "resolvedHost": "edge-595.bunnyinfra.net"
+        "resolvedHostname": "edge-595.bunnyinfra.net"
     },
     {
         "stats":
@@ -328,15 +346,16 @@
             "jMax": 29.7,
             "jAvg": 29.7
         },
-        "times":
+        "timings":
         [
             {
                 "seq": "33010",
-                "time": 29.687
+                "rtt": 29.687
             }
         ],
-        "host": "185.180.14.250",
-        "resolvedHost": "edge-595.bunnyinfra.net",
+        "asn": [],
+        "resolvedAddress": "185.180.14.250",
+        "resolvedHostname": "edge-595.bunnyinfra.net",
         "duplicate": true
     }
 ]

--- a/test/mocks/mtr-success-raw.json
+++ b/test/mocks/mtr-success-raw.json
@@ -2,6 +2,8 @@
     "testId": "test",
     "measurementId": "measurement",
     "result": {
+        "resolvedAddress": "142.250.179.238",
+        "resolvedHostname": "lhr25s31-in-f14.1e100.net",
         "hops":
         [
             {
@@ -18,22 +20,18 @@
                     "jMax": 2.3,
                     "jAvg": 2.3
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33000",
-                        "time": 2.27
+                        "rtt": 2.27
                     },
-                    {
-                        "seq": "33010"
-                    },
-                    {
-                        "seq": "33019"
-                    }
+                    {"rtt": null},
+                    {"rtt": null}
                 ],
-                "host": "192.168.0.1",
+                "asn": [],
+                "resolvedAddress": "192.168.0.1",
                 "duplicate": false,
-                "resolvedHost": "192.168.0.1"
+                "resolvedHostname": "192.168.0.1"
             },
             {
                 "stats":
@@ -49,18 +47,13 @@
                     "jMax": 0,
                     "jAvg": 0
                 },
-                "times":
+                "timings":
                 [
-                    {
-                        "seq": "33001"
-                    },
-                    {
-                        "seq": "33011"
-                    },
-                    {
-                        "seq": "33020"
-                    }
-                ]
+                    {"rtt": null},
+                    {"rtt": null},
+                    {"rtt": null}
+                ],
+                "asn": []
             },
             {
                 "stats":
@@ -76,25 +69,22 @@
                     "jMax": 11.3,
                     "jAvg": 6.2
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33002",
-                        "time": 10.394
+                        "rtt": 10.394
                     },
                     {
-                        "seq": "33012",
-                        "time": 9.222
+                        "rtt": 9.222
                     },
                     {
-                        "seq": "33021",
-                        "time": 11.276
+                        "rtt": 11.276
                     }
                 ],
-                "host": "62.252.67.181",
+                "resolvedAddress": "62.252.67.181",
                 "duplicate": false,
-                "resolvedHost": "62.252.67.181",
-                "asn": "123"
+                "resolvedHostname": "62.252.67.181",
+                "asn": [123]
             },
             {
                 "stats":
@@ -110,18 +100,13 @@
                     "jMax": 0,
                     "jAvg": 0
                 },
-                "times":
+                "timings":
                 [
-                    {
-                        "seq": "33003"
-                    },
-                    {
-                        "seq": "33013"
-                    },
-                    {
-                        "seq": "33022"
-                    }
-                ]
+                    {"rtt": null},
+                    {"rtt": null},
+                    {"rtt": null}
+                ],
+                "asn": []
             },
             {
                 "stats":
@@ -137,25 +122,22 @@
                     "jMax": 11.6,
                     "jAvg": 6.5
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33004",
-                        "time": 12.049
+                        "rtt": 12.049
                     },
                     {
-                        "seq": "33014",
-                        "time": 10.779
+                        "rtt": 10.779
                     },
                     {
-                        "seq": "33023",
-                        "time": 11.638
+                        "rtt": 11.638
                     }
                 ],
-                "host": "62.254.59.130",
+                "asn": [123],
+                "resolvedAddress": "62.254.59.130",
                 "duplicate": false,
-                "resolvedHost": "62.254.59.130",
-                "asn": "123"
+                "resolvedHostname": "62.254.59.130"
             },
             {
                 "stats":
@@ -171,25 +153,22 @@
                     "jMax": 11.4,
                     "jAvg": 6
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33005",
-                        "time": 10.949
+                        "rtt": 10.949
                     },
                     {
-                        "seq": "33015",
-                        "time": 11.595
+                        "rtt": 11.595
                     },
                     {
-                        "seq": "33024",
-                        "time": 11.393
+                        "rtt": 11.393
                     }
                 ],
-                "host": "142.250.160.116",
+                "asn": [123],
+                "resolvedAddress": "142.250.160.116",
                 "duplicate": false,
-                "resolvedHost": "142.250.160.116",
-                "asn": "123"
+                "resolvedHostname": "142.250.160.116"
             },
             {
                 "stats":
@@ -205,25 +184,22 @@
                     "jMax": 15.1,
                     "jAvg": 8
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33006",
-                        "time": 15.835
+                        "rtt": 15.835
                     },
                     {
-                        "seq": "33016",
-                        "time": 16.612
+                        "rtt": 16.612
                     },
                     {
-                        "seq": "33025",
-                        "time": 15.144
+                        "rtt": 15.144
                     }
                 ],
-                "host": "216.239.41.193",
+                "asn": [123],
+                "resolvedAddress": "216.239.41.193",
                 "duplicate": false,
-                "resolvedHost": "216.239.41.193",
-                "asn": "123"
+                "resolvedHostname": "216.239.41.193"
             },
             {
                 "stats":
@@ -239,25 +215,22 @@
                     "jMax": 12.9,
                     "jAvg": 8.2
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33007",
-                        "time": 15.666
+                        "rtt": 15.666
                     },
                     {
-                        "seq": "33017",
-                        "time": 12.228
+                        "rtt": 12.228
                     },
                     {
-                        "seq": "33026",
-                        "time": 12.872
+                        "rtt": 12.872
                     }
                 ],
-                "host": "142.251.54.27",
+                "asn": [123],
+                "resolvedAddress": "142.251.54.27",
                 "duplicate": false,
-                "resolvedHost": "142.251.54.27",
-                "asn": "123"
+                "resolvedHostname": "142.251.54.27"
             },
             {
                 "stats":
@@ -273,25 +246,22 @@
                     "jMax": 11.2,
                     "jAvg": 6.4
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33008",
-                        "time": 11.767
+                        "rtt": 11.767
                     },
                     {
-                        "seq": "33018",
-                        "time": 10.092
+                        "rtt": 10.092
                     },
                     {
-                        "seq": "33027",
-                        "time": 11.215
+                        "rtt": 11.215
                     }
                 ],
-                "host": "142.250.179.238",
+                "asn": [123],
+                "resolvedAddress": "142.250.179.238",
                 "duplicate": false,
-                "resolvedHost": "lhr25s31-in-f14.1e100.net",
-                "asn": "123"
+                "resolvedHostname": "lhr25s31-in-f14.1e100.net"
             },
             {
                 "stats":
@@ -307,17 +277,16 @@
                     "jMax": 11.4,
                     "jAvg": 11.4
                 },
-                "times":
+                "timings":
                 [
                     {
-                        "seq": "33009",
-                        "time": 11.352
+                        "rtt": 11.352
                     }
                 ],
-                "host": "142.250.179.238",
+                "asn": [123],
+                "resolvedAddress": "142.250.179.238",
                 "duplicate": true,
-                "resolvedHost": "lhr25s31-in-f14.1e100.net",
-                "asn": "123"
+                "resolvedHostname": "lhr25s31-in-f14.1e100.net"
             }
         ],
         "rawOutput": "Host                                                    Loss% Drop Rcv  Avg  StDev  Javg \n 1. AS??? _gateway (192.168.0.1)                        66.7%    2   1  2.3    0.0   2.3\n 2. AS??? (waiting for reply)                         \n 3. AS123 62.252.67.181 (62.252.67.181)                  0.0%    0   3 10.3    0.8   6.2\n 4. AS??? (waiting for reply)                         \n 5. AS123 62.254.59.130 (62.254.59.130)                  0.0%    0   3 11.5    0.5   6.5\n 6. AS123 142.250.160.116 (142.250.160.116)              0.0%    0   3 11.3    0.3   6.0\n 7. AS123 216.239.41.193 (216.239.41.193)                0.0%    0   3 15.9    0.6   8.0\n 8. AS123 142.251.54.27 (142.251.54.27)                  0.0%    0   3 13.6    1.5   8.2\n 9. AS123 lhr25s31-in-f14.1e100.net (142.250.179.238)    0.0%    0   3 11.0    0.7   6.4\n",

--- a/test/mocks/ping-success-linux.json
+++ b/test/mocks/ping-success-linux.json
@@ -3,14 +3,16 @@
   "measurementId": "measurement",
   "result": {
     "resolvedAddress": "172.217.20.206",
-    "min": 7.948,
-    "avg": 8.018,
-    "max": 8.120,
-    "loss": 0,
-    "times": [
-      {"time": 7.99, "ttl": 37},
-      {"time": 8.12, "ttl": 37},
-      {"time": 7.95, "ttl": 37}
+    "stats": {
+      "min": 7.948,
+      "avg": 8.018,
+      "max": 8.120,
+      "loss": 0
+    },
+    "timings": [
+      {"rtt": 7.99, "ttl": 37},
+      {"rtt": 8.12, "ttl": 37},
+      {"rtt": 7.95, "ttl": 37}
     ],
     "rawOutput": "PING google.com (172.217.20.206) 56(84) bytes of data.\n64 bytes from 172.217.20.206: icmp_seq=1 ttl=37 time=7.99 ms\n64 bytes from 172.217.20.206: icmp_seq=2 ttl=37 time=8.12 ms\n64 bytes from 172.217.20.206: icmp_seq=3 ttl=37 time=7.95 ms\n\n--- google.com ping statistics ---\n3 packets transmitted, 3 received, 0% packet loss, time 404ms\nrtt min/avg/max/mdev = 7.948/8.018/8.120/0.073 ms"
   }

--- a/test/mocks/ping-success-linux.json
+++ b/test/mocks/ping-success-linux.json
@@ -3,6 +3,7 @@
   "measurementId": "measurement",
   "result": {
     "resolvedAddress": "172.217.20.206",
+    "resolvedHostname": "lhr25s33-in-f14.1e100.net",
     "stats": {
       "min": 7.948,
       "avg": 8.018,
@@ -14,6 +15,6 @@
       {"rtt": 8.12, "ttl": 37},
       {"rtt": 7.95, "ttl": 37}
     ],
-    "rawOutput": "PING google.com (172.217.20.206) 56(84) bytes of data.\n64 bytes from 172.217.20.206: icmp_seq=1 ttl=37 time=7.99 ms\n64 bytes from 172.217.20.206: icmp_seq=2 ttl=37 time=8.12 ms\n64 bytes from 172.217.20.206: icmp_seq=3 ttl=37 time=7.95 ms\n\n--- google.com ping statistics ---\n3 packets transmitted, 3 received, 0% packet loss, time 404ms\nrtt min/avg/max/mdev = 7.948/8.018/8.120/0.073 ms"
+    "rawOutput": "PING google.com (172.217.20.206) 56(84) bytes of data.\n64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.206): icmp_seq=1 ttl=37 time=7.99 ms\n64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.206): icmp_seq=2 ttl=37 time=8.12 ms\n64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.206): icmp_seq=3 ttl=37 time=7.95 ms\n\n--- google.com ping statistics ---\n3 packets transmitted, 3 received, 0% packet loss, time 404ms\nrtt min/avg/max/mdev = 7.948/8.018/8.120/0.073 ms\n"
   }
 }

--- a/test/mocks/ping-success-linux.txt
+++ b/test/mocks/ping-success-linux.txt
@@ -1,7 +1,7 @@
 PING google.com (172.217.20.206) 56(84) bytes of data.
-64 bytes from 172.217.20.206: icmp_seq=1 ttl=37 time=7.99 ms
-64 bytes from 172.217.20.206: icmp_seq=2 ttl=37 time=8.12 ms
-64 bytes from 172.217.20.206: icmp_seq=3 ttl=37 time=7.95 ms
+64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.206): icmp_seq=1 ttl=37 time=7.99 ms
+64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.206): icmp_seq=2 ttl=37 time=8.12 ms
+64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.206): icmp_seq=3 ttl=37 time=7.95 ms
 
 --- google.com ping statistics ---
 3 packets transmitted, 3 received, 0% packet loss, time 404ms

--- a/test/mocks/ping-success-mac.json
+++ b/test/mocks/ping-success-mac.json
@@ -3,15 +3,17 @@
   "measurementId": "measurement",
   "result": {
     "resolvedAddress": "172.217.20.174",
-    "times": [
-      {"ttl": 58, "time": 7.271},
-      {"ttl": 58, "time": 11.055},
-      {"ttl": 58, "time": 7.782}
+    "timings": [
+      {"ttl": 58, "rtt": 7.271},
+      {"ttl": 58, "rtt": 11.055},
+      {"ttl": 58, "rtt": 7.782}
     ],
-    "min": 7.271,
-    "avg": 8.703,
-    "max": 11.055,
-    "loss": 0,
+    "stats": {
+      "min": 7.271,
+      "avg": 8.703,
+      "max": 11.055,
+      "loss": 0
+    },
     "rawOutput": "PING google.com (172.217.20.174): 56 data bytes\n64 bytes from 172.217.20.174: icmp_seq=0 ttl=58 time=7.271 ms\n64 bytes from 172.217.20.174: icmp_seq=1 ttl=58 time=11.055 ms\n64 bytes from 172.217.20.174: icmp_seq=2 ttl=58 time=7.782 ms\n\n--- google.com ping statistics ---\n3 packets transmitted, 3 packets received, 0.0% packet loss\nround-trip min/avg/max/stddev = 7.271/8.703/11.055/1.676 ms"
   }
 }

--- a/test/mocks/ping-success-mac.json
+++ b/test/mocks/ping-success-mac.json
@@ -3,6 +3,7 @@
   "measurementId": "measurement",
   "result": {
     "resolvedAddress": "172.217.20.174",
+    "resolvedHostname": "lhr25s33-in-f14.1e100.net",
     "timings": [
       {"ttl": 58, "rtt": 7.271},
       {"ttl": 58, "rtt": 11.055},
@@ -14,6 +15,6 @@
       "max": 11.055,
       "loss": 0
     },
-    "rawOutput": "PING google.com (172.217.20.174): 56 data bytes\n64 bytes from 172.217.20.174: icmp_seq=0 ttl=58 time=7.271 ms\n64 bytes from 172.217.20.174: icmp_seq=1 ttl=58 time=11.055 ms\n64 bytes from 172.217.20.174: icmp_seq=2 ttl=58 time=7.782 ms\n\n--- google.com ping statistics ---\n3 packets transmitted, 3 packets received, 0.0% packet loss\nround-trip min/avg/max/stddev = 7.271/8.703/11.055/1.676 ms"
+    "rawOutput": "PING google.com (172.217.20.174): 56 data bytes\n64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.174): icmp_seq=0 ttl=58 time=7.271 ms\n64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.174): icmp_seq=1 ttl=58 time=11.055 ms\n64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.174): icmp_seq=2 ttl=58 time=7.782 ms\n\n--- google.com ping statistics ---\n3 packets transmitted, 3 packets received, 0.0% packet loss\nround-trip min/avg/max/stddev = 7.271/8.703/11.055/1.676 ms\n"
   }
 }

--- a/test/mocks/ping-success-mac.txt
+++ b/test/mocks/ping-success-mac.txt
@@ -1,7 +1,7 @@
 PING google.com (172.217.20.174): 56 data bytes
-64 bytes from 172.217.20.174: icmp_seq=0 ttl=58 time=7.271 ms
-64 bytes from 172.217.20.174: icmp_seq=1 ttl=58 time=11.055 ms
-64 bytes from 172.217.20.174: icmp_seq=2 ttl=58 time=7.782 ms
+64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.174): icmp_seq=0 ttl=58 time=7.271 ms
+64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.174): icmp_seq=1 ttl=58 time=11.055 ms
+64 bytes from lhr25s33-in-f14.1e100.net (172.217.20.174): icmp_seq=2 ttl=58 time=7.782 ms
 
 --- google.com ping statistics ---
 3 packets transmitted, 3 packets received, 0.0% packet loss

--- a/test/mocks/ping-timeout-linux.json
+++ b/test/mocks/ping-timeout-linux.json
@@ -3,6 +3,7 @@
   "measurementId": "measurement",
   "result": {
     "resolvedAddress": "123.21.43.124",
+    "resolvedHostname": "",
     "timings": [],
     "stats": {
       "loss": 100

--- a/test/mocks/ping-timeout-linux.json
+++ b/test/mocks/ping-timeout-linux.json
@@ -3,8 +3,10 @@
   "measurementId": "measurement",
   "result": {
     "resolvedAddress": "123.21.43.124",
-    "times": [],
-    "loss": 100,
+    "timings": [],
+    "stats": {
+      "loss": 100
+    },
     "rawOutput": "PING 123.21.43.124 (123.21.43.124) 56(84) bytes of data.\n\n--- 123.21.43.124 ping statistics ---\n15 packets transmitted, 0 received, 100% packet loss, time 2909ms"
   }
 }

--- a/test/mocks/ping-timeout-mac.json
+++ b/test/mocks/ping-timeout-mac.json
@@ -3,8 +3,10 @@
   "measurementId": "measurement",
   "result": {
     "resolvedAddress": "172.13.23.43",
-    "times": [],
-    "loss": 100,
+    "timings": [],
+    "stats": {
+      "loss": 100
+    },
     "rawOutput": "PING 172.13.23.43 (172.13.23.43): 56 data bytes\nRequest timeout for icmp_seq 0\nRequest timeout for icmp_seq 1\n\n--- 172.13.23.43 ping statistics ---\n3 packets transmitted, 0 packets received, 100.0% packet loss"
   }
 }

--- a/test/mocks/ping-timeout-mac.json
+++ b/test/mocks/ping-timeout-mac.json
@@ -3,6 +3,7 @@
   "measurementId": "measurement",
   "result": {
     "resolvedAddress": "172.13.23.43",
+    "resolvedHostname": "",
     "timings": [],
     "stats": {
       "loss": 100

--- a/test/mocks/trace-success-linux.json
+++ b/test/mocks/trace-success-linux.json
@@ -2,48 +2,48 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
-    "destination": "216.239.38.21",
+    "resolvedAddress": "216.239.38.21",
     "hops": [
       {
-        "host": "192.168.0.1",
+        "resolvedHostname": "192.168.0.1",
         "resolvedAddress": "192.168.0.1",
-        "rtt": [
-          1.619,
-          2.465
+        "timings": [
+          { "rtt": 1.619 },
+          { "rtt": 2.465 }
         ]
       },
       {
-        "host": "*",
+        "resolvedHostname": "*",
         "resolvedAddress": "*",
-        "rtt": []
+        "timings": []
       },
       {
-        "host": "lutn-core-2a-xe-7114-0.network.virginmedia.net",
+        "resolvedHostname": "lutn-core-2a-xe-7114-0.network.virginmedia.net",
         "resolvedAddress": "62.252.67.181",
-        "rtt": [
-          27.688,
-          27.991
+        "timings": [
+          { "rtt": 27.688 },
+          { "rtt": 27.991 }
         ]
       },
       {
-        "host": "*",
+        "resolvedHostname": "*",
         "resolvedAddress": "*",
-        "rtt": []
+        "timings": []
       },
       {
-        "host": "eislou2-ic-4-ae0-0.network.virginmedia.net",
+        "resolvedHostname": "eislou2-ic-4-ae0-0.network.virginmedia.net",
         "resolvedAddress": "62.254.59.130",
-        "rtt": [
-          28.512,
-          28.192
+        "timings": [
+          { "rtt": 28.512 },
+          { "rtt": 28.192 }
         ]
       },
       {
-        "host": "142.250.160.116",
+        "resolvedHostname": "142.250.160.116",
         "resolvedAddress": "142.250.160.116",
-        "rtt": [
-          28.629,
-          35.934
+        "timings": [
+          { "rtt": 28.629 },
+          { "rtt": 35.934 }
         ]
       }
     ],

--- a/test/mocks/trace-success-linux.json
+++ b/test/mocks/trace-success-linux.json
@@ -3,6 +3,7 @@
   "measurementId": "measurement",
   "result": {
     "resolvedAddress": "216.239.38.21",
+    "resolvedHostname": "142.250.160.116",
     "hops": [
       {
         "resolvedHostname": "192.168.0.1",

--- a/test/unit/cmd/helpers/dig/trace.test.ts
+++ b/test/unit/cmd/helpers/dig/trace.test.ts
@@ -12,7 +12,7 @@ describe('dig trace helper', () => {
 			const parsedOutput = TraceDigParser.parse(rawOutput);
 
 			expect(parsedOutput).to.not.be.instanceof(Error);
-			expect((parsedOutput as DnsParseResponse).result.length).to.equal(4);
+			expect((parsedOutput as DnsParseResponse).hops.length).to.equal(4);
 		});
 	});
 });

--- a/test/unit/cmd/http.test.ts
+++ b/test/unit/cmd/http.test.ts
@@ -382,7 +382,7 @@ describe('http command', () => {
 					tls: {
 						authorized: true,
 						createdAt: (new Date(cert.valid_from)).toISOString(),
-						expireAt: (new Date(cert.valid_from)).toISOString(),
+						expiresAt: (new Date(cert.valid_from)).toISOString(),
 						issuer: {
 							...cert.issuer,
 						},

--- a/test/unit/cmd/http.test.ts
+++ b/test/unit/cmd/http.test.ts
@@ -11,8 +11,8 @@ import {
 import type {Timings} from '../../../src/command/http-command.js';
 
 type StreamCert = {
-	valid_from: number;
-	valid_to: number;
+	valid_from: number | string;
+	valid_to: number | string;
 	issuer: {
 		[k: string]: string;
 		CN: string;
@@ -47,13 +47,16 @@ class Stream {
 	response: StreamResponse | undefined;
 	timings: Timings | undefined;
 	stream: PassThrough;
+	ip: string;
 
 	constructor(
 		response: StreamResponse,
+		ip: string,
 	) {
 		this.stream = new PassThrough();
 		this.response = response;
 		this.timings = response?.timings;
+		this.ip = ip;
 	}
 
 	on(key: string, fn: (..._args: any[]) => void) {
@@ -190,6 +193,7 @@ describe('http command', () => {
 			const expectedResult = {
 				measurementId: 'measurement',
 				result: {
+					resolvedAddress: '1.1.1.1',
 					headers: {
 						test: 'abc',
 					},
@@ -210,7 +214,7 @@ describe('http command', () => {
 				testId: 'test',
 			};
 
-			const stream = new Stream(response);
+			const stream = new Stream(response, '1.1.1.1');
 			const mockHttpCmd = (): Request => stream as never;
 
 			const http = new HttpCommand(mockHttpCmd);
@@ -271,6 +275,7 @@ describe('http command', () => {
 			const expectedResult = {
 				measurementId: 'measurement',
 				result: {
+					resolvedAddress: '1.1.1.1',
 					headers: {
 						test: 'abc',
 					},
@@ -291,7 +296,7 @@ describe('http command', () => {
 				testId: 'test',
 			};
 
-			const stream = new Stream(response);
+			const stream = new Stream(response, '1.1.1.1');
 			const mockHttpCmd = (): Request => stream as never;
 
 			const http = new HttpCommand(mockHttpCmd);
@@ -319,8 +324,8 @@ describe('http command', () => {
 
 			/* eslint-disable @typescript-eslint/naming-convention */
 			const cert = {
-				valid_from: 100,
-				valid_to: 200,
+				valid_from: (new Date(1_657_802_359_042)).toUTCString(),
+				valid_to: (new Date(1_657_802_359_042)).toUTCString(),
 				issuer: {
 					CN: 'abc ltd',
 				},
@@ -362,6 +367,7 @@ describe('http command', () => {
 			const expectedResult = {
 				measurementId: 'measurement',
 				result: {
+					resolvedAddress: '1.1.1.1',
 					headers: {
 						test: 'abc',
 					},
@@ -375,8 +381,8 @@ describe('http command', () => {
 					},
 					tls: {
 						authorized: true,
-						createdAt: 100,
-						expireAt: 200,
+						createdAt: (new Date(cert.valid_from)).toISOString(),
+						expireAt: (new Date(cert.valid_from)).toISOString(),
 						issuer: {
 							...cert.issuer,
 						},
@@ -393,7 +399,7 @@ describe('http command', () => {
 				testId: 'test',
 			};
 
-			const stream = new Stream(response);
+			const stream = new Stream(response, '1.1.1.1');
 			const mockHttpCmd = (): Request => stream as never;
 
 			const http = new HttpCommand(mockHttpCmd);
@@ -439,6 +445,7 @@ describe('http command', () => {
 			const expectedResult = {
 				measurementId: 'measurement',
 				result: {
+					resolvedAddress: '',
 					headers: {},
 					rawHeaders: '',
 					rawBody: '',
@@ -453,7 +460,7 @@ describe('http command', () => {
 				testId: 'test',
 			};
 
-			const stream = new Stream(response);
+			const stream = new Stream(response, '');
 
 			const mockHttpCmd = (): Request => stream as never;
 


### PR DESCRIPTION
resolve https://github.com/jsdelivr/globalping/issues/157
1. ping
 - [x] 1.1 wrap `{ avg, loss, max, min }` in `stats` object.
 - [x] 1.2 Remove the `-n` parameter we call it with, to get resolved hostnames in the output.
 - [x] 1.3 Add `resolvedHostname` to the result, which is the last hostname in the output.
 - [x] 1.4. Rename `times` to `timings` for consistency. Rename `time` to `rtt`. Example: `timings: [{ rtt: 0.5, ttl: 100 }, ...]`

2. traceroute
 - [x] 2.1 Rename `result.destination` to `result.resolvedAddress` for consistency with everything else.
 - [x] 2.2 In hops, rename `host` to `resolvedHostname`.
 - [x] 2.3 Add `resolvedHostname` to the result, which is the `resolvedHostname` of the last hop.
 - [x] 2.4 Change the `rtt` array to `timings: [{ rtt: 1.2 }, { rtt: 0.5 }, ...]`.

3. dns
 - [x] 3.1 Rename the `server` field to `resolver` to mirror the input name.
 - [x] 3.2 Change `time: number` field to `timings: { total: number }`.
 - [x] 3.3 Probably rename `answer` to `answers`.
 - [x] 3.4 Rename `domain` in answer to `name`.
 - [x] 3.5 Does it make sense to provide `ttl` as number instead of a string? We do seem to parse numeric values everywhere else.
 - [x] 3.6 For `trace: true` the results array is currently nested as `result.result`, I think we can rename it to `result.hops` since this is more or less traceroute on dns level (and the repeated nesting looks stupid).

4. mtr
 - [x] 4.1 Add `resolvedHostname` and `resolvedAddress` (from the last hop).
 - [x] 4.2 Rename the current `resolvedHost` field to `resolvedHostname` and the `host` field to `resolvedAddress`.
 - [x] 4.3 Rename `times` to `timings` and change format to `timings: [{ rtt }, ...]` - `rtt` is the current `time` value and the `seq` value is removed.
 - [x] 4.4 Similar to point 3.5, AS should be an array of numbers.

5. http
 - [x] 5.1 Add `result.resolvedAddress` for http.
 - [x] 5.2 Change TLS dates to ISO format.