### PR TITLE
fix: enforce keepAlive headers to be false

### DIFF
--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -106,8 +106,11 @@ export const httpCmd = (options: HttpOptions, resolverFn?: ResolverType): Reques
 			downloadLimit: 10_000,
 		},
 		agent: {
-			http: new http.Agent({keepAlive: false}),
-			https: new https.Agent({maxCachedSessions: 0, keepAlive: false}),
+			// Ensure Connection: closed header is used - https://nodejs.org/api/http.html#new-agentoptions
+			/* eslint-disable unicorn/prefer-number-properties */
+			http: new http.Agent({keepAlive: false, maxSockets: Infinity}),
+			https: new https.Agent({maxCachedSessions: 0, keepAlive: false, maxSockets: Infinity}),
+			/* eslint-enable unicorn/prefer-number-properties */
 			http2: new http2.Agent({maxCachedTlsSessions: 1}),
 		},
 	};

--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -107,10 +107,10 @@ export const httpCmd = (options: HttpOptions, resolverFn?: ResolverType): Reques
 		},
 		agent: {
 			// Ensure Connection: closed header is used - https://nodejs.org/api/http.html#new-agentoptions
-			/* eslint-disable unicorn/prefer-number-properties */
+			// eslint-disable-next-line unicorn/prefer-number-properties
 			http: new http.Agent({keepAlive: false, maxSockets: Infinity}),
+			// eslint-disable-next-line unicorn/prefer-number-properties
 			https: new https.Agent({maxCachedSessions: 0, keepAlive: false, maxSockets: Infinity}),
-			/* eslint-enable unicorn/prefer-number-properties */
 			http2: new http2.Agent({maxCachedTlsSessions: 1}),
 		},
 	};

--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -106,8 +106,8 @@ export const httpCmd = (options: HttpOptions, resolverFn?: ResolverType): Reques
 			downloadLimit: 10_000,
 		},
 		agent: {
-			http: http.globalAgent,
-			https: new https.Agent({maxCachedSessions: 0}),
+			http: new http.Agent({keepAlive: false}),
+			https: new https.Agent({maxCachedSessions: 0, keepAlive: false}),
 			http2: new http2.Agent({maxCachedTlsSessions: 1}),
 		},
 	};

--- a/test/unit/cmd/http.test.ts
+++ b/test/unit/cmd/http.test.ts
@@ -155,9 +155,9 @@ describe('http command', () => {
 			const options = {
 				type: 'http',
 				target: 'google.com',
+				protocol: 'http',
 				query: {
 					method: 'get',
-					protocol: 'http',
 					path: '/400',
 				},
 			};

--- a/test/unit/cmd/http.test.ts
+++ b/test/unit/cmd/http.test.ts
@@ -79,7 +79,7 @@ describe('http command', () => {
 	describe('with httCmd', () => {
 		nock('http://google.com')
 			.get('/400')
-			.times(2)
+			.times(3)
 			.reply(400, '400 Bad Request', {
 				test: 'abc',
 			});
@@ -149,6 +149,23 @@ describe('http command', () => {
 			expect(mockedSocket.emit.lastCall.args[0]).to.equal('probe:measurement:result');
 			expect(mockedSocket.emit.lastCall.args[1]).to.have.nested.property('result.rawBody', expectedResult.result.rawBody);
 			expect(mockedSocket.emit.lastCall.args[1]).to.have.nested.property('result.rawHeaders', expectedResult.result.rawHeaders);
+		});
+
+		it('should ensure keepAlive header is disabled', () => {
+			const options = {
+				type: 'http',
+				target: 'google.com',
+				query: {
+					method: 'get',
+					protocol: 'http',
+					path: '/400',
+				},
+			};
+
+			const returnedOptions = httpCmd(options).options;
+
+			expect(returnedOptions.agent.http).to.have.property('keepAlive', false);
+			expect(returnedOptions.agent.https).to.have.property('keepAlive', false);
 		});
 	});
 


### PR DESCRIPTION
Resolves #79. Adds one test case. I don't think there is anything to do for http/2 since they [removed the relevant headers](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Keep-Alive) from the spec, right?