### PR TITLE
fix: use dig -x for ptr type

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -47,11 +47,12 @@ export const argBuilder = (options: DnsOptions): string[] => {
 	const protocolArg = options.protocol?.toLowerCase() === 'tcp' ? '+tcp' : [];
 	const resolverArg = options.resolver ? `@${options.resolver}` : [];
 	const traceArg = options.trace ? '+trace' : [];
+	const queryArg = options.query.type === 'PTR' ? '-x' : ['-t', options.query.type];
 
 	const args = [
 		options.target,
 		resolverArg,
-		['-t', options.query.type],
+		queryArg,
 		['-p', String(options.port)],
 		'-4',
 		'+timeout=3',

--- a/test/unit/cmd/dns.test.ts
+++ b/test/unit/cmd/dns.test.ts
@@ -114,7 +114,23 @@ describe('dns command', () => {
 				const args = argBuilder(options);
 				expect(args.join(' ')).to.contain('-t A');
 			});
+
+			it('should set -x PTR flag', () => {
+				const options = {
+					type: 'dns' as DnsOptions['type'],
+					target: '8.8.8.8',
+					resolver: '1.1.1.1',
+					port: 90,
+					query: {
+						type: 'PTR',
+					},
+				};
+
+				const args = argBuilder(options);
+				expect(args.join(' ')).to.contain('-x');
+			});
 		});
+
 		describe('protocol', () => {
 			it('should not add the flag (UDP)', () => {
 				const options = {


### PR DESCRIPTION
Use `dig -x` if PTR query is passed. Adds a test case to check.

I wasn't sure if we should be also passing `-t` if we're using `-x`? Can anyone confirm that it's not needed?