### PR TITLE
feat: parsing of ping execa errors

### DIFF
--- a/src/command/ping-command.ts
+++ b/src/command/ping-command.ts
@@ -114,10 +114,7 @@ export class PingCommand implements CommandInterface<PingOptions> {
 				isResultPrivate = true;
 			}
 		} catch (error: unknown) {
-			const output = isExecaError(error) ? error.stdout.toString() : '';
-			result = {
-				rawOutput: output,
-			};
+			result = isExecaError(error) ? this.parse(error.stdout.toString()) : {rawOutput: ''};
 		}
 
 		if (isResultPrivate) {


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/213

We can add error parsing to other commands, but currently I didn't found use cases with the same behavior. Behavior:
- command exits with non 0 exit code;
- command output has data that can be included in the result and it is not included currently.