### PR TITLE
feat: measurement statuses

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -137,12 +137,14 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 			}
 
 			result = {
+				status: 'failed',
 				rawOutput: output,
 			};
 		}
 
 		if (isResultPrivate) {
 			result = {
+				status: 'failed',
 				rawOutput: 'Private IP ranges are not allowed',
 			};
 		}

--- a/src/command/handlers/dig/classic.ts
+++ b/src/command/handlers/dig/classic.ts
@@ -11,10 +11,12 @@ import {
 } from './shared.js';
 
 export type DnsParseResponse = DnsParseLoopResponse & {
+	status: 'finished' | 'failed';
 	rawOutput: string;
 };
 
 export type DnsParseResponseJson = DnsParseLoopResponseJson & {
+	status: 'finished' | 'failed';
 	rawOutput: string;
 };
 
@@ -67,12 +69,14 @@ export const ClassicDigParser = {
 
 		return {
 			...ClassicDigParser.parseLoop(lines),
+			status: 'finished',
 			rawOutput,
 		};
 	},
 
 	toJsonOutput(input: DnsParseResponse): DnsParseResponseJson {
 		return {
+			status: input.status,
 			rawOutput: input.rawOutput,
 			answers: input.answers ?? [],
 			timings: {

--- a/src/command/handlers/dig/trace.ts
+++ b/src/command/handlers/dig/trace.ts
@@ -7,11 +7,13 @@ import {
 } from './shared.js';
 
 export type DnsParseResponse = {
+	status: 'finished' | 'failed';
 	hops: DnsParseLoopResponse[];
 	rawOutput: string;
 };
 
 export type DnsParseResponseJson = {
+	status: 'finished' | 'failed';
 	hops: DnsParseLoopResponseJson[];
 	rawOutput: string;
 };
@@ -43,6 +45,7 @@ export const TraceDigParser = {
 
 		return {
 			hops: TraceDigParser.parseLoop(lines.slice(2)),
+			status: 'finished',
 			rawOutput,
 		};
 	},
@@ -94,6 +97,7 @@ export const TraceDigParser = {
 
 	toJsonOutput(input: DnsParseResponse): DnsParseResponseJson {
 		return {
+			status: input.status,
 			rawOutput: input.rawOutput,
 			hops: input.hops.map(h => ({
 				answers: h.answers ?? [],

--- a/src/command/handlers/mtr/types.ts
+++ b/src/command/handlers/mtr/types.ts
@@ -32,6 +32,7 @@ export type ProgressType = {
 };
 
 export type ResultType = {
+	status: 'finished' | 'failed';
 	resolvedAddress?: string;
 	resolvedHostname?: string;
 	hops: HopType[];
@@ -41,6 +42,7 @@ export type ResultType = {
 
 /* eslint-disable @typescript-eslint/ban-types */
 export type ResultTypeJson = {
+	status: 'finished' | 'failed';
 	resolvedAddress: string | null;
 	resolvedHostname: string | null;
 	hops: Array<{

--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -57,6 +57,7 @@ type Output = {
 
 /* eslint-disable @typescript-eslint/ban-types */
 export type OutputJson = {
+	status: 'finished' | 'failed';
 	resolvedAddress: string | null;
 	headers: Record<string, string>;
 	rawHeaders: string | null;
@@ -275,6 +276,7 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 
 	private toJsonOutput(input: Output): OutputJson {
 		return {
+			status: 'finished',
 			resolvedAddress: input.resolvedAddress || null,
 			headers: input.headers,
 			rawHeaders: input.rawHeaders || null,

--- a/src/command/mtr-command.ts
+++ b/src/command/mtr-command.ts
@@ -35,7 +35,7 @@ const mtrOptionsSchema = Joi.object<MtrOptions>({
 	port: Joi.number(),
 });
 
-export const getResultInitState = () => ({hops: [], rawOutput: '', data: []});
+export const getResultInitState = (): ResultType => ({status: 'finished', hops: [], rawOutput: '', data: []});
 
 export const argBuilder = (options: MtrOptions): string[] => {
 	const intervalArg = ['--interval', String(getConfValue('commands.mtr.interval'))];
@@ -107,6 +107,7 @@ export class MtrCommand implements CommandInterface<MtrOptions> {
 			await cmd;
 			result = await this.parseResult(result.hops, result.data, true);
 		} catch (error: unknown) {
+			result.status = 'failed';
 			if (isExecaError(error)) {
 				result.rawOutput = error.stdout.toString();
 			} else {
@@ -135,6 +136,7 @@ export class MtrCommand implements CommandInterface<MtrOptions> {
 		const lastHop = [...nHops].reverse().find(h => h.resolvedAddress && !h.duplicate);
 
 		return {
+			status: 'finished',
 			rawOutput,
 			hops: nHops,
 			data,
@@ -196,6 +198,7 @@ export class MtrCommand implements CommandInterface<MtrOptions> {
 
 	private toJsonOutput(input: ResultType): ResultTypeJson {
 		return {
+			status: input.status,
 			rawOutput: input.rawOutput,
 			resolvedAddress: input.resolvedAddress ? input.resolvedAddress : null,
 			resolvedHostname: input.resolvedHostname ? input.resolvedHostname : null,

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -33,6 +33,7 @@ type ParsedOutput = {
 /* eslint-disable @typescript-eslint/ban-types */
 type ParsedOutputJson = {
 	rawOutput: string;
+	status: 'finished' | 'failed';
 	resolvedAddress: string | null;
 	resolvedHostname: string | null;
 	hops: Array<{
@@ -119,12 +120,14 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 		} catch (error: unknown) {
 			const output = isExecaError(error) ? error.stdout.toString() : '';
 			result = {
+				status: 'failed',
 				rawOutput: output,
 			};
 		}
 
 		if (isResultPrivate) {
 			result = {
+				status: 'failed',
 				rawOutput: 'Private IP ranges are not allowed',
 			};
 		}
@@ -174,6 +177,7 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 	private toJsonOutput(input: ParsedOutput): ParsedOutputJson {
 		return {
 			rawOutput: input.rawOutput,
+			status: 'finished',
 			resolvedAddress: input.resolvedAddress === '*' || !input.resolvedAddress ? null : input.resolvedAddress,
 			resolvedHostname: input.resolvedHostname === '*' || !input.resolvedHostname ? null : input.resolvedHostname,
 			hops: input.hops ? input.hops.map((h: ParsedLine) => ({

--- a/test/mocks/dns-connection-refused-error-linux.json
+++ b/test/mocks/dns-connection-refused-error-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "failed",
     "rawOutput": ";; Connection to 8.8.8.8#212(8.8.8.8) for abc.com failed: connection refused.",
     "answers": [],
     "resolver": null,

--- a/test/mocks/dns-connection-refused-private-error-linux.json
+++ b/test/mocks/dns-connection-refused-private-error-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "failed",
     "rawOutput": ";; Connection to x.x.x.x#212(x.x.x.x) for abc.com failed: connection refused.",
     "answers": [],
     "resolver": null,

--- a/test/mocks/dns-resolved-private-ip-error-linux.json
+++ b/test/mocks/dns-resolved-private-ip-error-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "failed",
     "rawOutput": "Private IP ranges are not allowed",
     "answers": [],
     "resolver": null,

--- a/test/mocks/dns-resolver-error-linux.json
+++ b/test/mocks/dns-resolver-error-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "failed",
     "rawOutput": "dig: couldn't get address for 'sdsa': not found\n",
     "answers": [],
     "resolver": null,

--- a/test/mocks/dns-success-linux.json
+++ b/test/mocks/dns-success-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+		"status": "finished",
 		"answers": [
 			{
 				"name": "google.com.",

--- a/test/mocks/dns-trace-resolved-private-ip-error-linux.json
+++ b/test/mocks/dns-trace-resolved-private-ip-error-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "failed",
     "rawOutput": "Private IP ranges are not allowed",
     "hops": []
   }

--- a/test/mocks/dns-trace-success.json
+++ b/test/mocks/dns-trace-success.json
@@ -3,6 +3,7 @@
     "measurementId": "measurement",
     "result":
     {
+        "status": "finished",
         "hops":
         [
             {

--- a/test/mocks/mtr-fail-private-ip.json
+++ b/test/mocks/mtr-fail-private-ip.json
@@ -2,6 +2,7 @@
     "testId": "test",
     "measurementId": "measurement",
     "result": {
+      "status": "failed",
       "resolvedAddress": null,
       "resolvedHostname": null,
       "hops": [],

--- a/test/mocks/mtr-success-raw.json
+++ b/test/mocks/mtr-success-raw.json
@@ -2,6 +2,7 @@
     "testId": "test",
     "measurementId": "measurement",
     "result": {
+        "status": "finished",
         "resolvedAddress": "142.250.179.238",
         "resolvedHostname": "lhr25s31-in-f14.1e100.net",
         "hops":

--- a/test/mocks/ping-private-ip-linux.json
+++ b/test/mocks/ping-private-ip-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "failed",
     "resolvedAddress": null,
     "resolvedHostname": null,
     "stats": {

--- a/test/mocks/ping-success-linux.json
+++ b/test/mocks/ping-success-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "finished",
     "resolvedAddress": "172.217.20.206",
     "resolvedHostname": "lhr25s33-in-f14.1e100.net",
     "stats": {

--- a/test/mocks/ping-success-mac.json
+++ b/test/mocks/ping-success-mac.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "finished",
     "resolvedAddress": "172.217.20.174",
     "resolvedHostname": "lhr25s33-in-f14.1e100.net",
     "timings": [

--- a/test/mocks/ping-timeout-linux.json
+++ b/test/mocks/ping-timeout-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "finished",
     "resolvedAddress": "123.21.43.124",
     "resolvedHostname": null,
     "timings": [],

--- a/test/mocks/ping-timeout-mac.json
+++ b/test/mocks/ping-timeout-mac.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "finished",
     "resolvedAddress": "172.13.23.43",
     "resolvedHostname": null,
     "timings": [],

--- a/test/mocks/trace-private-ip-linux.json
+++ b/test/mocks/trace-private-ip-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "failed",
     "rawOutput": "Private IP ranges are not allowed"
   }
 }

--- a/test/mocks/trace-success-linux.json
+++ b/test/mocks/trace-success-linux.json
@@ -2,6 +2,7 @@
   "testId": "test",
   "measurementId": "measurement",
   "result": {
+    "status": "finished",
     "resolvedAddress": "216.239.38.21",
     "resolvedHostname": "142.250.160.116",
     "hops": [

--- a/test/unit/command/dns-command.test.ts
+++ b/test/unit/command/dns-command.test.ts
@@ -339,7 +339,7 @@ describe('dns command', () => {
 			expect(mockSocket.emit.lastCall.args).to.deep.equal(['probe:measurement:result', expectedResult]);
 		});
 
-		it('should return connection refused error - dns-connection-refused-error-linux', async () => {
+		it('should fail in case of connection refused - dns-connection-refused-error-linux', async () => {
 			const testCase = 'dns-connection-refused-error-linux';
 			const options = {
 				type: 'dns' as const,
@@ -375,7 +375,7 @@ describe('dns command', () => {
 			expect(mockSocket.emit.lastCall.args).to.deep.equal(['probe:measurement:result', expectedResult]);
 		});
 
-		it('should return connection refused error - dns-connection-refused-private-error-linux (PRIVATE IP)', async () => {
+		it('should fail in case of connection refused with private ip - dns-connection-refused-private-error-linux (PRIVATE IP)', async () => {
 			const testCase = 'dns-connection-refused-private-error-linux';
 			const options = {
 				type: 'dns' as const,

--- a/test/unit/command/dns-command.test.ts
+++ b/test/unit/command/dns-command.test.ts
@@ -240,7 +240,7 @@ describe('dns command', () => {
 			expect(mockSocket.emit.lastCall.args).to.deep.equal(['probe:measurement:result', expectedResult]);
 		});
 
-		it('should return ExecaError - dns-resolver-error-linux', async () => {
+		it('should fail in case of execa error - dns-resolver-error-linux', async () => {
 			const testCase = 'dns-resolver-error-linux';
 			const options = {
 				type: 'dns' as const,
@@ -266,7 +266,7 @@ describe('dns command', () => {
 			expect(mockSocket.emit.firstCall.args[1]).to.deep.equal(expectedResult);
 		});
 
-		it('should return private IP error - dns-resolved-private-ip-error-linux', async () => {
+		it('should fail in case of private ip - dns-resolved-private-ip-error-linux', async () => {
 			const testCase = 'dns-resolved-private-ip-error-linux';
 			const options = {
 				type: 'dns' as const,
@@ -302,7 +302,7 @@ describe('dns command', () => {
 			expect(mockSocket.emit.lastCall.args).to.deep.equal(['probe:measurement:result', expectedResult]);
 		});
 
-		it('should return private IP error - dns-trace-resolved-private-ip-error-linux', async () => {
+		it('should fail in case of private ip - dns-trace-resolved-private-ip-error-linux', async () => {
 			const testCase = 'dns-trace-resolved-private-ip-error-linux';
 			const options = {
 				type: 'dns' as const,

--- a/test/unit/command/ping-command.test.ts
+++ b/test/unit/command/ping-command.test.ts
@@ -106,7 +106,7 @@ describe('ping command executor', () => {
 			});
 		}
 
-		it('should run and parse private ip command on the progress step', async () => {
+		it('should run and fail private ip command on the progress step', async () => {
 			const command = 'ping-private-ip-linux';
 			const rawOutput = getCmdMock(command);
 			const outputProgress = rawOutput.split('\n');
@@ -130,7 +130,7 @@ describe('ping command executor', () => {
 			expect(mockedSocket.emit.firstCall.args).to.deep.equal(['probe:measurement:result', expectedResult]);
 		});
 
-		it('should run and parse private ip command on the result step', async () => {
+		it('should run and fail private ip command on the result step', async () => {
 			const command = 'ping-private-ip-linux';
 			const rawOutput = getCmdMock(command);
 			const expectedResult = getCmdMockResult(command);

--- a/test/unit/command/ping-command.test.ts
+++ b/test/unit/command/ping-command.test.ts
@@ -168,5 +168,27 @@ describe('ping command executor', () => {
 				expect(mockedSocket.emit.firstCall.args[1]).to.deep.equal(expectedResult);
 			});
 		}
+
+		it('should fail in case of output without header', async () => {
+			const mockedCmd = getExecaMock();
+			const ping = new PingCommand((): any => mockedCmd);
+
+			const runPromise = ping.run(mockedSocket as any, 'measurement', 'test', {target: 'google.com'});
+			mockedCmd.resolve({stdout: ''});
+			await runPromise;
+
+			expect(mockedSocket.emit.firstCall.args).to.deep.equal(['probe:measurement:result', {
+				testId: 'test',
+				measurementId: 'measurement',
+				result: {
+					status: 'failed',
+					rawOutput: '',
+					resolvedAddress: null,
+					resolvedHostname: null,
+					timings: [],
+					stats: {min: null, max: null, avg: null, loss: null},
+				},
+			}]);
+		});
 	});
 });

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -19,7 +19,6 @@ const fakeLocation = {
 describe('index module', () => {
 	let sandbox: sinon.SinonSandbox;
 	const execaStub = sinon.stub();
-	const gotStub = sinon.stub();
 	const runStub = sinon.stub();
 	const PingCommandStub = sinon.stub().returns({
 		run: runStub,
@@ -48,7 +47,6 @@ describe('index module', () => {
 	before(async () => {
 		await td.replaceEsm('execa', {execa: execaStub});
 		await td.replaceEsm('socket.io-client', {io: ioStub});
-		await td.replaceEsm('got', null, gotStub);
 		await td.replaceEsm('../../src/command/ping-command.ts', {PingCommand: PingCommandStub, pingCmd: pingCmdStub});
 	});
 
@@ -58,7 +56,6 @@ describe('index module', () => {
 
 	afterEach(() => {
 		execaStub.reset();
-		gotStub.reset();
 		runStub.reset();
 		for (const stub of Object.values(handlers)) {
 			stub.reset();


### PR DESCRIPTION
Adds status field to the result field of the measurement. Possible values are: `in-progress`, `finished`, and `failed`.
Part of https://github.com/jsdelivr/globalping/issues/212