### PR TITLE
ci: mark working directory safe

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,9 @@ jobs:
 
       - uses: actions/checkout@v3
 
+      - name: Mark the working directory as safe
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
+
       - name: Build
         run: |
           npm install


### PR DESCRIPTION
This PR adds an additional step in the "Release" CI job to mark the working directory as a git safe.

This will fix the error below that prevents the `semantic-release` from creating a new release.

```
Error message: detected dubious ownership in repository
```