### PR TITLE
feat: probe status from boolean to string

### DIFF
--- a/src/helper/api-connect-handler.ts
+++ b/src/helper/api-connect-handler.ts
@@ -10,9 +10,9 @@ export const apiConnectLocationHandler = (socket: Socket) => async (data: ProbeL
 	logger.info(`connected from (${data.city}, ${data.country}, ${data.continent}) (lat: ${data.latitude} long: ${data.longitude})`);
 
 	if (await hasRequiredDeps()) {
-		socket.emit('probe:status:ready', {});
+		socket.emit('probe:status:update', 'ready');
 	} else {
-		socket.emit('probe:status:not_ready', {});
+		socket.emit('probe:status:update', 'unbuffer-missing');
 	}
 
 	const dnsList = getDnsServers();

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,7 +133,7 @@ function connect() {
 		logger.debug('SIGTERM received');
 
 		worker.active = false;
-		socket.emit('probe:status:not_ready', {});
+		socket.emit('probe:status:update', 'sigterm');
 
 		const closeTimeout = setTimeout(() => {
 			logger.debug('SIGTERM timeout. Force close.');

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -27,12 +27,11 @@ describe('index module', () => {
 
 	const mockSocket = new MockSocket();
 	const handlers = {
-		'probe:status:ready': sinon.stub(),
+		'probe:status:update': sinon.stub(),
 		'probe:dns:update': sinon.stub(),
 		'probe:measurement:request': sinon.stub(),
 		'probe:measurement:ack': sinon.stub(),
 		'connect_error': sinon.stub(),
-		'probe:status:not_ready': sinon.stub(),
 	};
 	const connectStub = sinon.stub();
 	const disconnectStub = sinon.stub();
@@ -84,8 +83,8 @@ describe('index module', () => {
 		});
 		expect(execaStub.secondCall.args).to.deep.equal(['which', ['unbuffer']]);
 		await sandbox.clock.nextAsync();
-		expect(handlers['probe:status:ready'].calledOnce).to.be.true;
-		expect(handlers['probe:status:ready'].firstCall.args).to.deep.equal([{}]);
+		expect(handlers['probe:status:update'].callCount).to.equal(1);
+		expect(handlers['probe:status:update'].firstCall.args).to.deep.equal(['ready']);
 		expect(handlers['probe:dns:update'].calledOnce).to.be.true;
 	});
 
@@ -148,7 +147,8 @@ describe('index module', () => {
 
 		process.once('SIGTERM', () => {
 			sandbox.clock.tick(150);
-			expect(handlers['probe:status:not_ready'].calledOnce).to.be.true;
+			expect(handlers['probe:status:update'].calledOnce).to.be.true;
+			expect(handlers['probe:status:update'].firstCall.args).to.deep.equal(['sigterm']);
 			expect(exitStub.calledOnce).to.be.true;
 		});
 
@@ -163,7 +163,8 @@ describe('index module', () => {
 
 		process.once('SIGTERM', () => {
 			sandbox.clock.tick(60_500);
-			expect(handlers['probe:status:not_ready'].calledOnce).to.be.true;
+			expect(handlers['probe:status:update'].calledOnce).to.be.true;
+			expect(handlers['probe:status:update'].firstCall.args).to.deep.equal(['sigterm']);
 			expect(exitStub.calledOnce).to.be.true;
 		});
 


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/296
Should be deployed in parallel with https://github.com/jsdelivr/globalping/pull/297 . In that order:
1. Release https://github.com/jsdelivr/globalping-probe/pull/116 and pick by the probes
2. Deploy https://github.com/jsdelivr/globalping/pull/297