### PR TITLE
fix: fix probes stuck in the INITIALIZING status

### DIFF
--- a/src/lib/status-manager.ts
+++ b/src/lib/status-manager.ts
@@ -39,10 +39,8 @@ export class StatusManager {
 	}
 
 	public updateStatus(status: StatusManager['status']) {
-		if (status !== this.status) {
-			this.status = status;
-			this.sendStatus();
-		}
+		this.status = status;
+		this.sendStatus();
 	}
 
 	public sendStatus() {
@@ -66,7 +64,7 @@ export class StatusManager {
 		const results = await Promise.allSettled([
 			this.pingCmd({type: 'ping', target: 'l.root-servers.net', packets: 10}),
 			this.pingCmd({type: 'ping', target: 'k.root-servers.net', packets: 10}),
-			this.pingCmd({type: 'ping', target: 'i.root-servers.net', packets: 10}),
+			this.pingCmd({type: 'ping', target: 'j.root-servers.net', packets: 10}),
 		]);
 
 		const rejectedPromises = results.filter((promise): promise is PromiseRejectedResult => promise.status === 'rejected');

--- a/test/unit/lib/status-manager.test.ts
+++ b/test/unit/lib/status-manager.test.ts
@@ -58,7 +58,7 @@ describe('StatusManager', () => {
 		expect(pingCmd.callCount).to.equal(3);
 		expect(pingCmd.args[0]).to.deep.equal([{type: 'ping', target: 'l.root-servers.net', packets: 10}]);
 		expect(pingCmd.args[1]).to.deep.equal([{type: 'ping', target: 'k.root-servers.net', packets: 10}]);
-		expect(pingCmd.args[2]).to.deep.equal([{type: 'ping', target: 'i.root-servers.net', packets: 10}]);
+		expect(pingCmd.args[2]).to.deep.equal([{type: 'ping', target: 'j.root-servers.net', packets: 10}]);
 		expect(statusManager.getStatus()).to.equal('ping-test-failed');
 		expect(socket.emit.callCount).to.equal(1);
 		expect(socket.emit.args[0]).to.deep.equal(['probe:status:update', 'ping-test-failed']);
@@ -112,13 +112,13 @@ describe('StatusManager', () => {
 		expect(pingCmd.callCount).to.equal(3);
 		expect(pingCmd.args[0]).to.deep.equal([{type: 'ping', target: 'l.root-servers.net', packets: 10}]);
 		expect(pingCmd.args[1]).to.deep.equal([{type: 'ping', target: 'k.root-servers.net', packets: 10}]);
-		expect(pingCmd.args[2]).to.deep.equal([{type: 'ping', target: 'i.root-servers.net', packets: 10}]);
+		expect(pingCmd.args[2]).to.deep.equal([{type: 'ping', target: 'j.root-servers.net', packets: 10}]);
 		expect(statusManager.getStatus()).to.equal('ready');
 		expect(socket.emit.callCount).to.equal(1);
 		expect(socket.emit.args[0]).to.deep.equal(['probe:status:update', 'ready']);
 	});
 
-	it('should run check in a fixed intervals and do not emit if status doesn`t change', async () => {
+	it('should run check in a fixed intervals and do emit with a status every time', async () => {
 		const statusManager = initStatusManager(socket, pingCmd);
 		expect(pingCmd.callCount).to.equal(0);
 		await statusManager.start();
@@ -127,7 +127,7 @@ describe('StatusManager', () => {
 		expect(socket.emit.args[0]).to.deep.equal(['probe:status:update', 'ready']);
 		await sandbox.clock.tickAsync(11 * 60 * 1000);
 		expect(pingCmd.callCount).to.equal(6);
-		expect(socket.emit.callCount).to.equal(1);
+		expect(socket.emit.callCount).to.equal(2);
 	});
 
 	it('should update the status during regular checks', async () => {


### PR DESCRIPTION
Socket.IO provides an at most once guarantee of delivery. That means we can't cache and rely on the local status of the probe, as API may loose the message and status there will be different. That is why we should send probe status on every check. Since that happens once in 10 mins and the payload is a few words that will not add any additional load to the system.

https://socket.io/docs/v4/delivery-guarantees#at-most-once