### PR TITLE
feat: send custom resolver in the failed dns response

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -94,7 +94,7 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 
 		const buffer = new ProgressBuffer(socket, testId, measurementId);
 		let isResultPrivate = false;
-		let result = {};
+		let result: Record<string, any> = {};
 
 		const cmd = this.cmd(cmdOptions);
 
@@ -165,6 +165,7 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 			result = {
 				status: 'failed',
 				rawOutput: 'Private IP ranges are not allowed',
+				resolver: result['resolver'] as string | undefined,
 			};
 		}
 
@@ -187,17 +188,17 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 	}
 
 	private toJsonOutput (
-		input: DnsParseResponseClassic | DnsParseResponseTrace,
+		result: DnsParseResponseClassic | DnsParseResponseTrace,
 		trace: boolean,
 	): DnsParseResponseClassicJson | DnsParseResponseTraceJson {
 		if (trace) {
 			return TraceDigParser.toJsonOutput({
-				...input,
-				hops: (input.hops || []) as DnsParseResponseTrace['hops'],
+				...result,
+				hops: (result.hops || []) as DnsParseResponseTrace['hops'],
 			} as DnsParseResponseTrace);
 		}
 
-		return ClassicDigParser.toJsonOutput(input as DnsParseResponseClassic);
+		return ClassicDigParser.toJsonOutput(result as DnsParseResponseClassic);
 	}
 
 	private hasResultPrivateIp (result: DnsParseResponseClassic | DnsParseResponseTrace): boolean {

--- a/src/command/handlers/dig/classic.ts
+++ b/src/command/handlers/dig/classic.ts
@@ -81,17 +81,17 @@ export const ClassicDigParser = {
 		};
 	},
 
-	toJsonOutput (input: DnsParseResponse): DnsParseResponseJson {
+	toJsonOutput (result: DnsParseResponse): DnsParseResponseJson {
 		return {
-			status: input.status,
-			statusCodeName: input.statusCodeName ?? null,
-			statusCode: input.statusCode ?? null,
-			rawOutput: input.rawOutput,
-			answers: input.answers ?? [],
+			status: result.status,
+			statusCodeName: result.statusCodeName ?? null,
+			statusCode: result.statusCode ?? null,
+			rawOutput: result.rawOutput,
+			answers: result.answers ?? [],
 			timings: {
-				...(input.timings ?? { total: 0 }),
+				...(result.timings ?? { total: 0 }),
 			},
-			resolver: input.resolver ?? null,
+			resolver: result.resolver ?? null,
 		};
 	},
 

--- a/src/command/handlers/dig/trace.ts
+++ b/src/command/handlers/dig/trace.ts
@@ -92,11 +92,11 @@ export const TraceDigParser = {
 		}));
 	},
 
-	toJsonOutput (input: DnsParseResponse): DnsParseResponseJson {
+	toJsonOutput (result: DnsParseResponse): DnsParseResponseJson {
 		return {
-			status: input.status,
-			rawOutput: input.rawOutput,
-			hops: input.hops.map(h => ({
+			status: result.status,
+			rawOutput: result.rawOutput,
+			hops: result.hops.map(h => ({
 				answers: h.answers ?? [],
 				timings: {
 					...(h.timings ?? { total: 0 }),

--- a/test/mocks/dns-resolved-private-ip-error-linux.json
+++ b/test/mocks/dns-resolved-private-ip-error-linux.json
@@ -7,7 +7,7 @@
 		"statusCode": null,
 		"rawOutput": "Private IP ranges are not allowed",
 		"answers": [],
-		"resolver": null,
+		"resolver": "private",
 		"timings": {
 			"total": 0
 		}


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/345 for dns.
Problem is not actual for other types of measurement.