### PR TITLE
fix: fix ptr dns type

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -26,12 +26,12 @@ export type DnsOptions = {
 	type: 'dns';
 	inProgressUpdates: boolean;
 	target: string;
-	protocol?: string;
-	port?: number;
+	protocol: string;
+	port: number;
 	resolver?: string;
 	trace?: boolean;
 	query: {
-		type?: string;
+		type: string;
 	};
 };
 
@@ -56,15 +56,15 @@ const dnsOptionsSchema = Joi.object<DnsOptions>({
 });
 
 export const argBuilder = (options: DnsOptions): string[] => {
-	const protocolArg = options.protocol?.toLowerCase() === 'tcp' ? '+tcp' : [];
+	const protocolArg = options.protocol.toLowerCase() === 'tcp' ? '+tcp' : [];
 	const resolverArg = options.resolver ? `@${options.resolver}` : [];
 	const traceArg = options.trace ? '+trace' : [];
 	const queryArg = options.query.type === 'PTR' ? '-x' : [ '-t', options.query.type ];
 
 	const args = [
+		queryArg,
 		options.target,
 		resolverArg,
-		queryArg,
 		[ '-p', String(options.port) ],
 		'-4',
 		'+timeout=3',
@@ -72,7 +72,7 @@ export const argBuilder = (options: DnsOptions): string[] => {
 		'+nocookie',
 		traceArg,
 		protocolArg,
-	].flat() as string[];
+	].flat();
 
 	return args;
 };

--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -21,6 +21,7 @@ import type {
 } from './handlers/dig/trace.js';
 import { isDnsSection } from './handlers/dig/shared.js';
 import type { DnsParseLoopResponse } from './handlers/dig/shared.js';
+import type { DeepPartial } from '../lib/types.js';
 
 export type DnsOptions = {
 	type: 'dns';
@@ -85,7 +86,7 @@ export const dnsCmd = (options: DnsOptions): ExecaChildProcess => {
 export class DnsCommand implements CommandInterface<DnsOptions> {
 	constructor (private readonly cmd: typeof dnsCmd) {}
 
-	async run (socket: Socket, measurementId: string, testId: string, options: DnsOptions): Promise<void> {
+	async run (socket: Socket, measurementId: string, testId: string, options: DeepPartial<DnsOptions>): Promise<void> {
 		const { value: cmdOptions, error: validationError } = dnsOptionsSchema.validate(options);
 
 		if (validationError) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,3 @@
+export type DeepPartial<T> = T extends Record<string, any> ? {
+	[P in keyof T]?: DeepPartial<T[P]>;
+} : T;

--- a/test/unit/command/dns-command.test.ts
+++ b/test/unit/command/dns-command.test.ts
@@ -32,17 +32,16 @@ describe('dns command', () => {
 			};
 
 			const args = argBuilder(options);
+			console.log(args);
 
-			expect(args[0]).to.equal(options.target);
+			expect([ args[0], args[1], args[2], args[3] ]).to.deep.equal([ '-t', 'TXT', 'google.com', '@1.1.1.1' ]);
 			expect(args.join(' ')).to.include(`-t ${options.query.type}`);
 			expect(args).to.include('-4');
 			expect(args).to.include('+timeout=3');
 			expect(args).to.include('+tries=2');
 			expect(args).to.include('+nocookie');
-			// Optional values
-			expect(args[1]).to.equal(`@${options.resolver}`);
-			// Udp has no flag
-			expect(args).to.not.include('udp');
+			// Optional values:
+			expect(args).to.not.include('udp'); // Udp has no flag
 			expect(args).to.include('+trace');
 		});
 
@@ -90,6 +89,7 @@ describe('dns command', () => {
 					type: 'dns' as DnsOptions['type'],
 					target: 'google.com',
 					resolver: '1.1.1.1',
+					protocol: 'UDP',
 					port: 90,
 					query: {
 						type: 'TXT',
@@ -103,11 +103,12 @@ describe('dns command', () => {
 		});
 
 		describe('type', () => {
-			it('should set -t A flag', () => {
+			it('should set -t A flag before the target', () => {
 				const options = {
 					type: 'dns' as DnsOptions['type'],
 					target: 'google.com',
 					resolver: '1.1.1.1',
+					protocol: 'UDP',
 					port: 90,
 					query: {
 						type: 'A',
@@ -116,14 +117,15 @@ describe('dns command', () => {
 				};
 
 				const args = argBuilder(options);
-				expect(args.join(' ')).to.contain('-t A');
+				expect(args.join(' ')).to.contain('-t A google.com');
 			});
 
-			it('should set -x PTR flag', () => {
+			it('should set -x flag before the target', () => {
 				const options = {
 					type: 'dns' as DnsOptions['type'],
 					target: '8.8.8.8',
 					resolver: '1.1.1.1',
+					protocol: 'UDP',
 					port: 90,
 					query: {
 						type: 'PTR',
@@ -132,7 +134,7 @@ describe('dns command', () => {
 				};
 
 				const args = argBuilder(options);
-				expect(args.join(' ')).to.contain('-x');
+				expect(args.join(' ')).to.contain('-x 8.8.8.8');
 			});
 		});
 


### PR DESCRIPTION
Fixes: https://github.com/jsdelivr/globalping-probe/issues/139

Broken version of command:
`dig 172.67.208.113 @1.1.1.1 -x -p 53 -4 +timeout=3 +tries=2 +nocookie`
Fixed:
`dig -x 172.67.208.113 @1.1.1.1 -p 53 -4 +timeout=3 +tries=2 +nocookie `

All other dns types and args combinations work fine before and after the fix.