### PR TITLE
feat: add +nsid to dns commands

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -71,6 +71,7 @@ export const argBuilder = (options: DnsOptions): string[] => {
 		'+timeout=3',
 		'+tries=2',
 		'+nocookie',
+		'+nsid',
 		traceArg,
 		protocolArg,
 	].flat();

--- a/test/unit/command/dns-command.test.ts
+++ b/test/unit/command/dns-command.test.ts
@@ -32,7 +32,6 @@ describe('dns command', () => {
 			};
 
 			const args = argBuilder(options);
-			console.log(args);
 
 			expect([ args[0], args[1], args[2], args[3] ]).to.deep.equal([ '-t', 'TXT', 'google.com', '@1.1.1.1' ]);
 			expect(args.join(' ')).to.include(`-t ${options.query.type}`);
@@ -40,6 +39,7 @@ describe('dns command', () => {
 			expect(args).to.include('+timeout=3');
 			expect(args).to.include('+tries=2');
 			expect(args).to.include('+nocookie');
+			expect(args).to.include('+nsid');
 			// Optional values:
 			expect(args).to.not.include('udp'); // Udp has no flag
 			expect(args).to.include('+trace');


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping-probe/issues/149

Example of the response:
```
; <<>> DiG 9.16.37-Debian <<>> -t A jsdelivr.com @1.1.1.1 -p 53 -4 +timeout=3 +tries=2 +nocookie +nsid
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 3432
;; flags: qr rd ra; QUERY: 1, ANSWER: 2, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 1232
; NSID: 38 37 6d 33 36 32 ("87m362")
;; QUESTION SECTION:
;jsdelivr.com.			IN	A

;; ANSWER SECTION:
jsdelivr.com.		300	IN	A	104.21.23.24
jsdelivr.com.		300	IN	A	172.67.208.113

;; Query time: 34 msec
;; SERVER: 1.1.1.1#53(1.1.1.1)
;; WHEN: Thu May 25 09:17:09 UTC 2023
;; MSG SIZE  rcvd: 83
```