### PR TITLE
refactor: replace `_.random` with Node.js native `crypto.randomInt` API

### DIFF
--- a/src/lib/restart.ts
+++ b/src/lib/restart.ts
@@ -1,11 +1,11 @@
 import config from 'config';
 import process from 'node:process';
-import _ from 'lodash';
+import { randomInt } from 'node:crypto';
 import { scopedLogger } from './logger.js';
 
 const logger = scopedLogger('health-restart');
 const uptimeConfig = config.get<{interval: number; maxDeviation: number; maxUptime: number}>('uptime');
-const uptimeInterval = uptimeConfig.interval + _.random(0, uptimeConfig.maxDeviation);
+const uptimeInterval = uptimeConfig.interval + randomInt(0, uptimeConfig.maxDeviation);
 
 const checkUptime = () => {
 	const uptime = process.uptime();

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,6 +1,6 @@
 import config from 'config';
 import process from 'node:process';
-import _ from 'lodash';
+import { randomInt } from 'node:crypto';
 import got, { TimeoutError } from 'got';
 import { VERSION } from '../constants.js';
 import { scopedLogger } from './logger.js';
@@ -11,7 +11,7 @@ type ReleaseInfo = {
 
 const logger = scopedLogger('self-update');
 const updateConfig = config.get<{releaseUrl: string; interval: number; maxDeviation: number}>('update');
-const updateInterval = updateConfig.interval + _.random(0, updateConfig.maxDeviation);
+const updateInterval = updateConfig.interval + randomInt(0, updateConfig.maxDeviation);
 
 const checkForUpdates = () => {
 	got(updateConfig.releaseUrl, { timeout: { request: 15_000 } }).json<ReleaseInfo>().then((releaseInfo) => {


### PR DESCRIPTION
An alternative approach of #174.

Replace `_.random` with Node.js native `crypto.randomInt` API (synchronous version), which is available since Node.js 14.10.0:

https://nodejs.org/dist/latest-v18.x/docs/api/crypto.html#cryptorandomintmin-max-callback

<img width="1502" alt="image" src="https://github.com/jsdelivr/globalping-probe/assets/40715044/20a1a817-9845-4073-a5f2-52df0909da0e">
