### PR TITLE
feat: separate probe and api errors

### DIFF
--- a/src/helper/api-error-handler.ts
+++ b/src/helper/api-error-handler.ts
@@ -3,10 +3,14 @@ import { scopedLogger } from '../lib/logger.js';
 
 const logger = scopedLogger('api:error');
 
-const fatalConnectErrors = [
-	'failed to collect probe metadata',
+const probeErrors = [
+	'ip limit',
 	'vpn detected',
 	'unresolvable geoip',
+];
+
+const apiErrors = [
+	'failed to collect probe metadata',
 ];
 
 class ErrorHandler {
@@ -27,13 +31,17 @@ class ErrorHandler {
 
 		this.socket.disconnect();
 
-		const isFatalError = fatalConnectErrors.some(fatalError => error.message.startsWith(fatalError));
+		const isProbeError = probeErrors.some(fatalError => error.message.startsWith(fatalError));
+		const isApiError = apiErrors.some(apiError => error.message.startsWith(apiError));
 
-		if (isFatalError) {
+		if (isProbeError) {
+			if (error.message.startsWith('ip limit')) {
+				logger.error(`Only 1 connection per IP address is allowed. Please make sure you don't have another probe running on IP ${error?.data?.ipAddress || ''}.`);
+			}
+
 			logger.error('Retrying in 1 hour. Probe temporarily disconnected.');
 			setTimeout(() => this.socket.connect(), 60 * 60 * 1000);
-		} else if (error.message.startsWith('ip limit')) {
-			logger.error(`Only 1 connection per IP address is allowed. Please make sure you don't have another probe running on IP ${error?.data?.ipAddress || ''}.`);
+		} else if (isApiError) {
 			logger.error('Retrying in 1 minute. Probe temporarily disconnected.');
 			setTimeout(() => this.socket.connect(), 60 * 1000);
 		} else {

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -172,10 +172,10 @@ describe('index module', () => {
 		expect(connectStub.calledOnce).to.be.true;
 	});
 
-	it('should reconnect after 1 hour delay on "connect_error" fatal errors', async () => {
+	it('should reconnect after 1 hour delay on "probe" type errors', async () => {
 		await import('../../src/index.js');
 
-		mockSocket.emit('connect_error', new Error('failed to collect probe metadata'));
+		mockSocket.emit('connect_error', new Error('ip limit'));
 		mockSocket.emit('connect_error', new Error('vpn detected'));
 		mockSocket.emit('connect_error', new Error('unresolvable geoip'));
 
@@ -185,10 +185,10 @@ describe('index module', () => {
 		expect(connectStub.callCount).to.equal(3);
 	});
 
-	it('should reconnect after 1 minute delay on "connect_error" with "ip limit"', async () => {
+	it('should reconnect after 1 minute delay on "api" type errors', async () => {
 		await import('../../src/index.js');
 
-		mockSocket.emit('connect_error', new Error('ip limit'));
+		mockSocket.emit('connect_error', new Error('failed to collect probe metadata'));
 
 		sandbox.clock.tick(1000 + 50);
 		expect(connectStub.callCount).to.equal(0);


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/417
- Updates to reconnect after 'ip limit' error in 1 hour.
- Updates to reconnect after 'failed to collect probe metadata' error in 1 min. (This is a consequence of the `fetchSockets timeout` on the API side, so reconnect should be done faster).