### PR TITLE
feat: update socket.io reconnect delay

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,8 +55,9 @@ function connect () {
 
 	const socket = io(`${config.get<string>('api.host')}/probes`, {
 		transports: [ 'websocket' ],
-		reconnectionDelay: 100,
-		reconnectionDelayMax: 500,
+		reconnectionDelay: 2000,
+		reconnectionDelayMax: 8000,
+		randomizationFactor: 0.75,
 		query: {
 			version: VERSION,
 			nodeVersion: process.version,

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -111,8 +111,9 @@ describe('index module', () => {
 
 		expect(ioStub.firstCall.args[1]).to.deep.include({
 			transports: [ 'websocket' ],
-			reconnectionDelay: 100,
-			reconnectionDelayMax: 500,
+			reconnectionDelay: 2000,
+			reconnectionDelayMax: 8000,
+			randomizationFactor: 0.75,
 		});
 
 		expect(ioStub.firstCall.args[1].query.version).to.match(/^\d+.\d+.\d+$/);


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping-probe/issues/179