### PR TITLE
build: use npm v10.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM node:18.19.1-bullseye-slim AS builder
 
 WORKDIR /app
 
+RUN npm install npm@10.5.2 -g
 COPY package.json package-lock.json tsconfig.json /app/
 RUN npm ci --include=dev
 COPY src /app/src
@@ -28,7 +29,7 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y expect ca-ce
     && rm -rf /var/cache/{apt,debconf,fontconfig,ldconfig}/* \
     && rm -rf /opt /root/.npm /usr/share/man /usr/lib/arm-linux-gnueabihf/perl-base /usr/include /usr/local/include /usr/local/lib/node_modules/npm/docs \
     && rm -rf /tmp/v8-compile-cache-0 /sbin/debugfs /sbin/e2fsck /sbin/ldconfig /usr/bin/perl* \
-    && cd /app && npm install --omit=dev --omit=optional
+    && cd /app && npm install npm@10.5.2 -g && npm install --omit=dev --omit=optional
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 


### PR DESCRIPTION
Lower 10.x.x versions have a bug that overloads the network and causes install failures: https://github.com/npm/cli/issues/7072