### PR TITLE
fix: reduce the size of log messages for update errors

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,9 +1,20 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return */
 import process from 'node:process';
 import { inspect } from 'node:util';
 import * as winston from 'winston';
 
-const objectFormatter = (object: Record<string, unknown>) => {
-	const objectWithoutSymbols = Object.fromEntries(Object.entries(object));
+const objectFormatter = (object: Record<string, any>) => {
+	const entries = Object.entries(object).map(([ key, value ]) => {
+		if (key === 'timings' && value && typeof value === 'object') {
+			return [ key, { phases: value.phases }];
+		} else if (key === 'options' && value && value.url && typeof value.url === 'object') {
+			return [ key, { url: { href: value.url.href } }];
+		}
+
+		return [ key, value ];
+	});
+
+	const objectWithoutSymbols = Object.fromEntries(entries);
 	return inspect(objectWithoutSymbols);
 };
 
@@ -13,7 +24,7 @@ const logger = winston.createLogger({
 		winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss' }),
 		winston.format.prettyPrint(),
 		winston.format.printf((info: winston.Logform.TransformableInfo) => {
-			const { timestamp, level, scope, message, stack, ...otherFields } = info; // eslint-disable-line @typescript-eslint/no-unsafe-assignment
+			const { timestamp, level, scope, message, stack, ...otherFields } = info;
 			let result = `[${timestamp as string}] [${level.toUpperCase()}] [${scope as string}] ${message as string}`;
 
 			if (Object.keys(otherFields).length > 0) {

--- a/src/lib/updater.ts
+++ b/src/lib/updater.ts
@@ -1,7 +1,7 @@
 import config from 'config';
 import process from 'node:process';
 import _ from 'lodash';
-import got, { TimeoutError } from 'got';
+import got, { HTTPError, RequestError, TimeoutError } from 'got';
 import { VERSION } from '../constants.js';
 import { scopedLogger } from './logger.js';
 
@@ -30,7 +30,15 @@ const checkForUpdates = () => {
 		process.kill(process.pid, 'SIGTERM');
 	}).catch((error: unknown) => {
 		if (error instanceof TimeoutError) {
-			logger.warn('The server timed out, while checking for a new version.');
+			logger.warn('The request timed out while checking for a new probe version.');
+			logger.warn(error);
+			return;
+		} else if (error instanceof HTTPError) {
+			logger.warn('The request failed with an HTTP error while checking for a new probe version.');
+			logger.warn(error);
+			return;
+		} else if (error instanceof RequestError) {
+			logger.warn('The request failed while checking for a new probe version.');
 			logger.warn(error);
 			return;
 		}

--- a/test/unit/lib/updater.test.ts
+++ b/test/unit/lib/updater.test.ts
@@ -5,6 +5,8 @@ import * as td from 'testdouble';
 import * as sinon from 'sinon';
 import * as constants from '../../../src/constants.js';
 
+class MockHTTPError extends Error {}
+class MockRequestError extends Error {}
 class MockTimeoutError extends Error {}
 
 describe('updater module', () => {
@@ -12,7 +14,11 @@ describe('updater module', () => {
 	const gotStub = sinon.stub();
 
 	before(async () => {
-		await td.replaceEsm('got', { TimeoutError: MockTimeoutError }, gotStub);
+		await td.replaceEsm('got', {
+			HTTPError: MockHTTPError,
+			RequestError: MockRequestError,
+			TimeoutError: MockTimeoutError,
+		}, gotStub);
 	});
 
 	beforeEach(() => {


### PR DESCRIPTION
A bit ugly but makes all got errors much shorter while keeping the important parts. Related: jsdelivr/globalping#550