### PR TITLE
build: cleanup docker image leftovers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,10 @@ RUN apt-get update -y && apt-get install --no-install-recommends -y expect ca-ce
     && apt-get clean && apt-get autoremove -y \
     && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log \
     && rm -rf /var/cache/apt /var/cache/debconf /var/cache/fontconfig /var/cache/ldconfig \
-    && rm -rf /opt /root/.npm /usr/share/man /usr/lib/arm-linux-gnueabihf/perl-base /usr/include /usr/local/include /usr/local/lib/node_modules/npm/docs \
-    && rm -rf /tmp/v8-compile-cache-0 /sbin/debugfs /sbin/e2fsck /sbin/ldconfig /usr/bin/perl* \
-    && cd /app && npm install --omit=dev --omit=optional
+    && rm -rf /opt /usr/share/man /usr/lib/arm-linux-gnueabihf/perl-base /usr/include /usr/local/include /usr/local/lib/node_modules/npm/docs \
+    && rm -rf /sbin/debugfs /sbin/e2fsck /sbin/ldconfig /usr/bin/perl* \
+    && cd /app && npm install --omit=dev --omit=optional \
+    && rm -rf /root/.npm /tmp/v8-compile-cache-0
 
 COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/config /app/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@ COPY --from=builder /app/package.json /app/package-lock.json /app/
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y expect ca-certificates iputils-ping traceroute dnsutils jq tini mtr-tiny curl \
     && apt-get clean && apt-get autoremove -y \
-    && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log \
-    && rm -rf /var/cache/apt /var/cache/debconf /var/cache/fontconfig /var/cache/ldconfig \
-    && rm -rf /opt /usr/share/man /usr/lib/arm-linux-gnueabihf/perl-base /usr/include /usr/local/include /usr/local/lib/node_modules/npm/docs \
-    && rm -rf /sbin/debugfs /sbin/e2fsck /sbin/ldconfig /usr/bin/perl* \
     && cd /app && npm install --omit=dev --omit=optional \
-    && rm -rf /root/.npm /tmp/v8-compile-cache-0
+    && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log \
+    && rm -rf /usr/share/icons /var/lib/X11 /var/lib/doc \
+    && rm -rf /var/cache/apt /var/cache/debconf /var/cache/fontconfig /var/cache/ldconfig \
+    && rm -rf /opt /root/.npm /usr/share/man /usr/lib/arm-linux-gnueabihf/perl-base /usr/include /usr/local/include /usr/local/lib/node_modules/npm/docs \
+    && rm -rf /sbin/debugfs /sbin/e2fsck /sbin/ldconfig /usr/bin/perl*
 
 COPY --from=builder /app/dist /app/dist
 COPY --from=builder /app/config /app/config

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ COPY --from=builder /app/package.json /app/package-lock.json /app/
 
 RUN apt-get update -y && apt-get install --no-install-recommends -y expect ca-certificates iputils-ping traceroute dnsutils jq tini mtr-tiny curl \
     && apt-get clean && apt-get autoremove -y \
-    && rm -rf /var/lib/{apt,dpkg,cache,log}/* \
-    && rm -rf /var/cache/{apt,debconf,fontconfig,ldconfig}/* \
+    && rm -rf /var/lib/apt /var/lib/dpkg /var/lib/cache /var/lib/log \
+    && rm -rf /var/cache/apt /var/cache/debconf /var/cache/fontconfig /var/cache/ldconfig \
     && rm -rf /opt /root/.npm /usr/share/man /usr/lib/arm-linux-gnueabihf/perl-base /usr/include /usr/local/include /usr/local/lib/node_modules/npm/docs \
     && rm -rf /tmp/v8-compile-cache-0 /sbin/debugfs /sbin/e2fsck /sbin/ldconfig /usr/bin/perl* \
     && cd /app && npm install --omit=dev --omit=optional

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,9 @@ WORKDIR /app
 
 COPY --from=builder /app/package.json /app/package-lock.json /app/
 
-RUN apt-get update -y && apt-get install --no-install-recommends -y expect ca-certificates iputils-ping traceroute dnsutils jq tini mtr curl \
+RUN apt-get update -y && apt-get install --no-install-recommends -y expect ca-certificates iputils-ping traceroute dnsutils jq tini mtr-tiny curl \
     && apt-get clean && apt-get autoremove -y \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/* \
-    && rm -rf /usr/share/{icons,X11,doc}/* \
     && rm -rf /var/cache/{apt,debconf,fontconfig,ldconfig}/* \
     && rm -rf /opt /root/.npm /usr/share/man /usr/lib/arm-linux-gnueabihf/perl-base /usr/include /usr/local/include /usr/local/lib/node_modules/npm/docs \
     && rm -rf /tmp/v8-compile-cache-0 /sbin/debugfs /sbin/e2fsck /sbin/ldconfig /usr/bin/perl* \


### PR DESCRIPTION
The Dockerfile had a couple of errors causing leftover in the resulting image.

This PR reduces the resulting image by around 80MB:

![CleanShot 2024-10-23 at 19 37 03](https://github.com/user-attachments/assets/6d235260-a0b7-4f42-9ed4-6b4158ca3b9e)
