### PR TITLE
feat: make the UUID persistent

### DIFF
--- a/src/probe.ts
+++ b/src/probe.ts
@@ -52,7 +52,7 @@ await loadAllDeps();
 
 const logger = scopedLogger('general');
 const handlersMap = new Map<string, CommandInterface<unknown>>();
-const probeUuid = randomUUID();
+const probeUuid = process.env['GP_PROBE_UUID'] || randomUUID();
 
 handlersMap.set('ping', process.env['FAKE_COMMANDS'] ? new FakePingCommand() : new PingCommand(pingCmd));
 handlersMap.set('mtr', process.env['FAKE_COMMANDS'] ? new FakeMtrCommand() : new MtrCommand(mtrCmd));


### PR DESCRIPTION
 - when `probe.ts` is ran directly (dev setup), UUID is different on each run like before
 - when `index.ts` is ran (docker setup), we read `GP_PROBE_UUID` first (may be set on HW probes), then read/write a file in the container