### PR TITLE
feat: add OPTIONS as an allowed HTTP Method

### DIFF
--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -216,7 +216,7 @@ export class HttpCommand implements CommandInterface<HttpOptions> {
 				rawOutput = result.error;
 			} else if (result.error) {
 				rawOutput = `HTTP/${result.httpVersion} ${result.statusCode}\n${result.rawHeaders}\n\n${result.error}`;
-			} else if (cmdOptions.request.method === 'HEAD') {
+			} else if (cmdOptions.request.method === 'HEAD' || !result.rawBody) {
 				rawOutput = `HTTP/${result.httpVersion} ${result.statusCode}\n${result.rawHeaders}`;
 			} else {
 				rawOutput = `HTTP/${result.httpVersion} ${result.statusCode}\n${result.rawHeaders}\n\n${result.rawBody}`;

--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -107,7 +107,7 @@ const getInitialResult = () => ({
 });
 
 const allowedHttpProtocols = [ 'HTTP', 'HTTPS', 'HTTP2' ];
-const allowedHttpMethods = [ 'GET', 'HEAD' ];
+const allowedHttpMethods = [ 'GET', 'HEAD', 'OPTIONS' ];
 const allowedIpVersions = [ 4, 6 ];
 
 export const httpOptionsSchema = Joi.object<HttpOptions>({
@@ -145,7 +145,7 @@ export const urlBuilder = (options: HttpOptions): string => {
 	return url;
 };
 
-export const httpCmd =	(options: HttpOptions, resolverFn?: ResolverType): Request => {
+export const httpCmd = (options: HttpOptions, resolverFn?: ResolverType): Request => {
 	const url = urlBuilder(options);
 	const dnsResolver = callbackify(dnsLookup(options.resolver, resolverFn), true);
 
@@ -166,6 +166,7 @@ export const httpCmd =	(options: HttpOptions, resolverFn?: ResolverType): Reques
 			'User-Agent': 'globalping probe (https://github.com/jsdelivr/globalping)',
 			'host': options.request.host ?? options.target,
 		},
+		...(options.request.method === 'OPTIONS' && { body: '' }), // https://github.com/sindresorhus/got/issues/2394
 		setHost: false,
 		throwHttpErrors: false,
 		context: {

--- a/wallaby.js
+++ b/wallaby.js
@@ -3,6 +3,7 @@ import * as url from 'node:url';
 
 export default function wallaby () {
 	const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
+
 	return {
 		testFramework: 'mocha',
 		files: [
@@ -12,7 +13,6 @@ export default function wallaby () {
 			'test/plugins/**/*',
 			'test/utils.ts',
 			'test/hooks.ts',
-			'test/setup.ts',
 			'test/snapshots/**/*.json',
 			'package.json',
 		],
@@ -22,7 +22,6 @@ export default function wallaby () {
 		setup (w) {
 			const path = require('path');
 			w.testFramework.files.unshift(path.resolve(process.cwd(), 'test/hooks.js'));
-			w.testFramework.files.unshift(path.resolve(process.cwd(), 'test/setup.js'));
 			const mocha = w.testFramework;
 			mocha.timeout(5000);
 		},


### PR DESCRIPTION
Part of https://github.com/jsdelivr/globalping-probe/issues/261