### PR TITLE
feat: update node.js to v22

### DIFF
--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -74,7 +74,7 @@ jobs:
           CURRENT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
           echo "Current branch: $CURRENT_BRANCH."
-          npm run test:e2e:cases
+          npm run test:e2e:clone
           cd test/e2e/globalping
           cp config/redis/.env.redis ./
           docker compose up -d

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -70,7 +70,10 @@ jobs:
           sudo systemctl restart docker
           docker restart $(docker ps -aq)
       - name: Set up Redis
+        env:
+          CURRENT_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
+          echo "Current branch: $CURRENT_BRANCH."
           npm run test:e2e:cases
           cd test/e2e/globalping
           cp config/redis/.env.redis ./
@@ -81,4 +84,5 @@ jobs:
           npm run build
       - name: Test E2E
         run: |
-          npm run test:e2e
+          npm run test:e2e:docker
+          npm run test:e2e:run

--- a/.github/workflows/_tests.yaml
+++ b/.github/workflows/_tests.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [ 18.x, 20.x ]
+        node-version: [ 18.x, 20.x, 22.x ]
       fail-fast: false
 
     env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ jobs:
     name: Release new version
 
     runs-on: ubuntu-latest
-    container: node:20.13.0-bullseye-slim
+    container: node:22.16.0-bullseye-slim
 
     needs: test
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,3 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
 # Add cygpath to PATH if missing to make this work with GitHub Desktop app
 # https://github.com/desktop/desktop/issues/12562
 if ! type cygpath > /dev/null 2>&1; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20.13.0-bullseye-slim AS builder
+FROM node:22.16.0-bullseye-slim AS builder
 
 WORKDIR /app
 
@@ -9,7 +9,7 @@ COPY config /app/config
 COPY @types /app/@types
 RUN npm run build
 
-FROM node:20.13.0-bullseye-slim
+FROM node:22.16.0-bullseye-slim
 
 ARG node_env=production
 ENV NODE_ENV=$node_env

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "globalping-probe",
 			"version": "0.38.0",
+			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {
 				"config": "^3.3.12",
@@ -18,6 +19,7 @@
 				"joi": "^17.13.3",
 				"lodash": "^4.17.21",
 				"nvm": "github:nvm-sh/nvm",
+				"patch-package": "^8.0.0",
 				"physical-cpu-count": "^2.0.0",
 				"socket.io-client": "^4.8.1",
 				"throng": "^5.0.0",
@@ -2787,6 +2789,12 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			}
 		},
+		"node_modules/@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+			"integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+			"license": "BSD-2-Clause"
+		},
 		"node_modules/acorn": {
 			"version": "8.14.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -2957,11 +2965,19 @@
 			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
 			"license": "MIT"
 		},
+		"node_modules/at-least-node": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+			"integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+			"license": "ISC",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/before-after-hook": {
@@ -2992,7 +3008,6 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -3003,7 +3018,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
 			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -3180,6 +3194,53 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/call-bind": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+			"integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.0",
+				"es-define-property": "^1.0.0",
+				"get-intrinsic": "^1.2.4",
+				"set-function-length": "^1.2.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/call-bind-apply-helpers": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/call-bound": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+			"integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"get-intrinsic": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -3267,6 +3328,21 @@
 			},
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/ci-info": {
+			"version": "3.9.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+			"integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/clean-stack": {
@@ -3773,7 +3849,6 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/config": {
@@ -4150,6 +4225,23 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/define-data-property": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+			"integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.0.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/diff": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -4184,6 +4276,20 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/dunder-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"gopd": "^1.2.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/duplexer2": {
@@ -4329,6 +4435,36 @@
 			"integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/es-define-property": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-errors": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/es-object-atoms": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+			"license": "MIT",
+			"dependencies": {
+				"es-errors": "^1.3.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			}
 		},
 		"node_modules/esbuild": {
 			"version": "0.25.4",
@@ -5103,7 +5239,6 @@
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
 			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -5158,6 +5293,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-yarn-workspace-root": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+			"integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"micromatch": "^4.0.2"
 			}
 		},
 		"node_modules/flat": {
@@ -5249,6 +5393,12 @@
 				"node": ">=14.14"
 			}
 		},
+		"node_modules/fs.realpath": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"license": "ISC"
+		},
 		"node_modules/fsevents": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -5268,7 +5418,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
 			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -5310,6 +5459,30 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/get-intrinsic": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind-apply-helpers": "^1.0.2",
+				"es-define-property": "^1.0.1",
+				"es-errors": "^1.3.0",
+				"es-object-atoms": "^1.1.1",
+				"function-bind": "^1.1.2",
+				"get-proto": "^1.0.1",
+				"gopd": "^1.2.0",
+				"has-symbols": "^1.1.0",
+				"hasown": "^2.0.2",
+				"math-intrinsics": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/get-own-enumerable-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/get-own-enumerable-keys/-/get-own-enumerable-keys-1.0.0.tgz",
@@ -5321,6 +5494,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/get-proto": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+			"license": "MIT",
+			"dependencies": {
+				"dunder-proto": "^1.0.1",
+				"es-object-atoms": "^1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/get-stream": {
@@ -5537,6 +5723,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/gopd": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/got": {
 			"version": "12.6.1",
 			"resolved": "https://registry.npmjs.org/got/-/got-12.6.1.tgz",
@@ -5578,7 +5776,6 @@
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/graphemer": {
@@ -5614,17 +5811,39 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/has-property-descriptors": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+			"integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+			"license": "MIT",
+			"dependencies": {
+				"es-define-property": "^1.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/has-symbols": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/hasown": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
 			"integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -5853,6 +6072,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/inflight": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+			"license": "ISC",
+			"dependencies": {
+				"once": "^1.3.0",
+				"wrappy": "1"
+			}
+		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -5920,6 +6150,21 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-docker": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+			"integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5960,7 +6205,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -6035,6 +6279,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/is-wsl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+			"integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/isarray": {
@@ -6202,11 +6458,36 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/json-stable-stringify": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+			"integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"isarray": "^2.0.5",
+				"jsonify": "^0.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
 			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/json-stable-stringify/node_modules/isarray": {
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+			"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
 			"license": "MIT"
 		},
 		"node_modules/json-stringify-safe": {
@@ -6282,13 +6563,21 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
 			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonify": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+			"integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+			"license": "Public Domain",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/jsonparse": {
@@ -6325,6 +6614,15 @@
 			"license": "MIT",
 			"dependencies": {
 				"json-buffer": "3.0.1"
+			}
+		},
+		"node_modules/klaw-sync": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+			"integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"node_modules/kuler": {
@@ -6804,6 +7102,15 @@
 				"marked": ">=1 <16"
 			}
 		},
+		"node_modules/math-intrinsics": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
 		"node_modules/meow": {
 			"version": "12.1.1",
 			"resolved": "https://registry.npmjs.org/meow/-/meow-12.1.1.tgz",
@@ -6837,7 +7144,6 @@
 			"version": "4.0.8",
 			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
 			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -6851,7 +7157,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -6917,7 +7222,6 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -6930,7 +7234,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -10048,6 +10351,24 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/object-keys": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
+			}
+		},
+		"node_modules/once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"license": "ISC",
+			"dependencies": {
+				"wrappy": "1"
+			}
+		},
 		"node_modules/one-time": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
@@ -10072,6 +10393,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/open": {
+			"version": "7.4.2",
+			"resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+			"integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/optionator": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -10088,6 +10425,15 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/os-tmpdir": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/p-cancelable": {
@@ -10278,6 +10624,143 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/patch-package": {
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+			"integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+			"license": "MIT",
+			"dependencies": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^3.7.0",
+				"cross-spawn": "^7.0.3",
+				"find-yarn-workspace-root": "^2.0.0",
+				"fs-extra": "^9.0.0",
+				"json-stable-stringify": "^1.0.2",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.6",
+				"open": "^7.4.2",
+				"rimraf": "^2.6.3",
+				"semver": "^7.5.3",
+				"slash": "^2.0.0",
+				"tmp": "^0.0.33",
+				"yaml": "^2.2.2"
+			},
+			"bin": {
+				"patch-package": "index.js"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">5"
+			}
+		},
+		"node_modules/patch-package/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"license": "MIT",
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/patch-package/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"license": "MIT",
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/patch-package/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/patch-package/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"license": "MIT"
+		},
+		"node_modules/patch-package/node_modules/fs-extra": {
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+			"integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+			"license": "MIT",
+			"dependencies": {
+				"at-least-node": "^1.0.0",
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/patch-package/node_modules/glob": {
+			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"license": "ISC",
+			"dependencies": {
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.1.1",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
+			},
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/patch-package/node_modules/rimraf": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+			"integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+			"deprecated": "Rimraf versions prior to v4 are no longer supported",
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^7.1.3"
+			},
+			"bin": {
+				"rimraf": "bin.js"
+			}
+		},
+		"node_modules/patch-package/node_modules/slash": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+			"integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/path-exists": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
@@ -10286,6 +10769,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			}
+		},
+		"node_modules/path-is-absolute": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/path-key": {
@@ -11275,7 +11767,6 @@
 			"version": "7.7.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
 			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -11321,6 +11812,23 @@
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"randombytes": "^2.1.0"
+			}
+		},
+		"node_modules/set-function-length": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+			"integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+			"license": "MIT",
+			"dependencies": {
+				"define-data-property": "^1.1.4",
+				"es-errors": "^1.3.0",
+				"function-bind": "^1.1.2",
+				"get-intrinsic": "^1.2.4",
+				"gopd": "^1.0.1",
+				"has-property-descriptors": "^1.0.2"
+			},
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -11904,7 +12412,6 @@
 			"version": "7.2.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -12188,11 +12695,22 @@
 			"integrity": "sha512-ECqb8imSroX1UmUuhRBNPkkmtZ8mHEenieim80UVxG0M5wXVjY2Fp2tYXCPvk+nLy1geOhFpeD5YQhM/gF63Jg==",
 			"license": "MIT"
 		},
+		"node_modules/tmp": {
+			"version": "0.0.33",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"license": "MIT",
+			"dependencies": {
+				"os-tmpdir": "~1.0.2"
+			},
+			"engines": {
+				"node": ">=0.6.0"
+			}
+		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -12454,7 +12972,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
 			"integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
@@ -12782,6 +13299,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"license": "ISC"
+		},
 		"node_modules/ws": {
 			"version": "8.17.1",
 			"resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
@@ -12835,7 +13358,6 @@
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
 			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
-			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
 				"typescript": "^5.8.3"
 			},
 			"engines": {
-				"node": "18 || 20"
+				"node": "18 || 20 || 22"
 			}
 		},
 		"node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
 		"test:mocha:dev:prune": "PRUNE_OLD_SNAPSHOTS=1 npm run test:mocha:dev",
 		"test:mocha:dev:update": "PRUNE_OLD_SNAPSHOTS=1 UPDATE_EXISTING_SNAPSHOTS=1 npm run test:mocha:dev",
 		"test:mocha:dev:updateNoPrune": "UPDATE_EXISTING_SNAPSHOTS=1 npm run test:mocha:dev",
-		"test:e2e": "CURRENT_BRANCH=$(git branch --show-current) && npm run test:e2e:cases && npm run test:e2e:docker && npm run test:e2e:run",
-		"test:e2e:cases": "git clone -b $CURRENT_BRANCH https://github.com/jsdelivr/globalping.git test/e2e/globalping || git clone https://github.com/jsdelivr/globalping.git test/e2e/globalping; cd test/e2e/globalping && git add . && git reset --hard && git pull --force && npm install; cd ../../../; for f in config/e2e-api-*; do cp \"$f\" \"test/e2e/globalping/config/${f#config/e2e-api-}\"; done;",
+		"test:e2e": "npm run test:e2e:clone && npm run test:e2e:docker && npm run test:e2e:run",
+		"test:e2e:clone": "./scripts/clone-gp-api.sh",
 		"test:e2e:docker": "docker build -t globalping-probe-e2e . && docker build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -t globalping-api-e2e test/e2e/globalping",
 		"test:e2e:run": "cd test/e2e/globalping; TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha --config ./.mocharc.e2e.cjs || E=$?; cd ../../../; exit $E;"
 	},

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"joi": "^17.13.3",
 		"lodash": "^4.17.21",
 		"nvm": "github:nvm-sh/nvm",
+		"patch-package": "^8.0.0",
 		"physical-cpu-count": "^2.0.0",
 		"socket.io-client": "^4.8.1",
 		"throng": "^5.0.0",
@@ -61,6 +62,7 @@
 		"typescript": "^5.8.3"
 	},
 	"scripts": {
+		"postinstall": "patch-package",
 		"build": "tsc && npm run copy:sh",
 		"coverage": "npm run clean && c8 npm run test:mocha",
 		"clean": "rimraf coverage",

--- a/package.json
+++ b/package.json
@@ -82,8 +82,8 @@
 		"test:mocha:dev:prune": "PRUNE_OLD_SNAPSHOTS=1 npm run test:mocha:dev",
 		"test:mocha:dev:update": "PRUNE_OLD_SNAPSHOTS=1 UPDATE_EXISTING_SNAPSHOTS=1 npm run test:mocha:dev",
 		"test:mocha:dev:updateNoPrune": "UPDATE_EXISTING_SNAPSHOTS=1 npm run test:mocha:dev",
-		"test:e2e": "npm run test:e2e:cases && npm run test:e2e:docker && npm run test:e2e:run",
-		"test:e2e:cases": "git clone https://github.com/jsdelivr/globalping.git test/e2e/globalping; cd test/e2e/globalping && git add . && git reset --hard && git pull --force && npm install; cd ../../../; for f in config/e2e-api-*; do cp \"$f\" \"test/e2e/globalping/config/${f#config/e2e-api-}\"; done;",
+		"test:e2e": "CURRENT_BRANCH=$(git branch --show-current) && npm run test:e2e:cases && npm run test:e2e:docker && npm run test:e2e:run",
+		"test:e2e:cases": "git clone -b $CURRENT_BRANCH https://github.com/jsdelivr/globalping.git test/e2e/globalping || git clone https://github.com/jsdelivr/globalping.git test/e2e/globalping; cd test/e2e/globalping && git add . && git reset --hard && git pull --force && npm install; cd ../../../; for f in config/e2e-api-*; do cp \"$f\" \"test/e2e/globalping/config/${f#config/e2e-api-}\"; done;",
 		"test:e2e:docker": "docker build -t globalping-probe-e2e . && docker build --build-arg BUILDKIT_CONTEXT_KEEP_GIT_DIR=1 -t globalping-api-e2e test/e2e/globalping",
 		"test:e2e:run": "cd test/e2e/globalping; TS_NODE_TRANSPILE_ONLY=true NODE_ENV=test mocha --config ./.mocharc.e2e.cjs || E=$?; cd ../../../; exit $E;"
 	},

--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
 		"*.{cjs,js,json,ts}": "eslint --cache --fix"
 	},
 	"engines": {
-		"node": "18 || 20"
+		"node": "18 || 20 || 22"
 	}
 }

--- a/patches/quibble+0.9.2.dev.patch
+++ b/patches/quibble+0.9.2.dev.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/quibble/lib/quibble.mjs b/node_modules/quibble/lib/quibble.mjs
+index 125db13..fa94b69 100644
+--- a/node_modules/quibble/lib/quibble.mjs
++++ b/node_modules/quibble/lib/quibble.mjs
+@@ -59,7 +59,7 @@ export async function resolve (specifier, context, nextResolve) {
+ 
+     const quibbledUrl = addQueryToUrl(url, '__quibble', stubModuleGeneration)
+ 
+-    if (url.startsWith('node:') && !getStubsInfo(quibbledUrl)) {
++    if ((url.startsWith('node:') || url.includes('node_modules')) && !getStubsInfo(quibbledUrl)) {
+       return { ...ctx, url } // It's allowed to change ctx for a builtin (but unlikely)
+     }
+ 

--- a/scripts/clone-gp-api.sh
+++ b/scripts/clone-gp-api.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+CURRENT_BRANCH=${CURRENT_BRANCH:-$(git rev-parse --abbrev-ref HEAD)}
+
+# Checkout and sync the branch if the directory exists, otherwise clone the repository
+if [ -d "test/e2e/globalping" ]; then
+  cd test/e2e/globalping
+  git add .
+  git reset --hard @{u}
+  git fetch
+  git checkout $CURRENT_BRANCH || git checkout master
+  git reset --hard @{u}
+else
+  git clone -b $CURRENT_BRANCH https://github.com/jsdelivr/globalping.git test/e2e/globalping || git clone https://github.com/jsdelivr/globalping.git test/e2e/globalping
+  cd test/e2e/globalping
+fi
+
+# Install dependencies
+npm install
+
+cd ../../../
+
+# Copy the e2e-api-* files to the globalping API directory
+for f in config/e2e-api-*; do
+  cp "$f" "test/e2e/globalping/config/${f#config/e2e-api-}"
+done

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 
 import { getAvailableDiskSpace, looksLikeV1HardwareDevice } from './lib/util.js';
 
-const WANTED_VERSION = 'v20.13.0';
+const WANTED_VERSION = 'v22.16.0';
 const MIN_NODE_UPDATE_MEMORY = 250 * 1e6;
 const MIN_NODE_UPDATE_DISK_SPACE_MB = 1000;
 const dirname = path.dirname(fileURLToPath(import.meta.url));


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping/issues/657

Looks like Node.js v24 drops support for `arm32v7`, so I am updating only to v22: https://github.com/nodejs/docker-node/issues/2232#issuecomment-2867510141 . Migration to v24 should be checked in a separate issue.

PR also updates e2e tests to prefer the gp-api branch with the same name instead of master, if possible.

