### PR TITLE
fix: fix reading resolver from dig response with greedy regex

### DIFF
--- a/src/command/handlers/dig/classic.ts
+++ b/src/command/handlers/dig/classic.ts
@@ -29,7 +29,7 @@ export type DnsParseResponseJson = DnsParseLoopResponseJson & {
 };
 
 const QUERY_TIME_REG_EXP = /Query\s+time:\s+(\d+)/g;
-const RESOLVER_REG_EXP = /SERVER:.*\((.*?)\)/g;
+const RESOLVER_REG_EXP = /SERVER:.*?\((.*?)\)/g;
 const STATUS_CODE_NAME_REG_EXP = /status:\s*([A-Z]+)/g;
 
 export const ClassicDigParser = {

--- a/test/mocks/ipv6-dns-success-ip.json
+++ b/test/mocks/ipv6-dns-success-ip.json
@@ -11,7 +11,7 @@
 			}
 		],
 		"rawOutput": "; <<>> DiG 9.18.18-0ubuntu0.22.04.2-Ubuntu <<>> -x 2a00:1450:4026:802::200e @2606:4700:4700::1111 -p 53 -6 +timeout=3 +tries=2 +nocookie +nosplit +nsid\n;; global options: +cmd\n;; Got answer:\n;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 47787\n;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 1\n\n;; OPT PSEUDOSECTION:\n; EDNS: version: 0, flags:; udp: 1232\n; NSID: 37 39 6d 32 31 37 (\"79m217\")\n;; QUESTION SECTION:\n;e.0.0.2.0.0.0.0.0.0.0.0.0.0.0.0.2.0.8.0.6.2.0.4.0.5.4.1.0.0.a.2.ip6.arpa. IN PTR\n\n;; ANSWER SECTION:\ne.0.0.2.0.0.0.0.0.0.0.0.0.0.0.0.2.0.8.0.6.2.0.4.0.5.4.1.0.0.a.2.ip6.arpa. 85385 IN PTR hem09s02-in-x0e.1e100.net.\n\n;; Query time: 0 msec\n;; SERVER: 2606:4700:4700::1111#53(2606:4700:4700::1111) (UDP)\n;; WHEN: Tue May 14 17:36:02 UTC 2024\n;; MSG SIZE  rcvd: 150\n",
-		"resolver": "UDP",
+		"resolver": "2606:4700:4700::1111",
 		"status": "finished",
 		"statusCode": 0,
 		"statusCodeName": "NOERROR",

--- a/test/mocks/ipv6-resolver-dns-success.json
+++ b/test/mocks/ipv6-resolver-dns-success.json
@@ -18,6 +18,6 @@
 		"timings": {
 			"total": 0
 		},
-		"resolver": "UDP"
+		"resolver": "2606:4700:4700::1111"
 	}
 }

--- a/test/snapshots/command/dns-command.test.json
+++ b/test/snapshots/command/dns-command.test.json
@@ -123,7 +123,7 @@
 				"timings": {
 					"total": 0
 				},
-				"resolver": "TCP"
+				"resolver": "8.8.8.8"
 			}
 		}
 	],
@@ -204,7 +204,7 @@
 				"timings": {
 					"total": 39
 				},
-				"resolver": "UDP"
+				"resolver": "8.8.8.8"
 			}
 		}
 	],
@@ -455,7 +455,7 @@
 				"timings": {
 					"total": 119
 				},
-				"resolver": "TCP"
+				"resolver": "8.8.8.8"
 			}
 		}
 	],
@@ -990,7 +990,7 @@
 				"timings": {
 					"total": 27
 				},
-				"resolver": "UDP"
+				"resolver": "8.8.8.8"
 			}
 		}
 	]


### PR DESCRIPTION
The regex used for reading the resolver from the DNS response was greedy and thus moved to the next bracket, which included, e.g., UDP / TCP. This happens for some dig responses, but not all. This fix unifies the behavior by fixing the regex to be lazy and thus reading out the resolver's IP address, which is in the first brackets.