### PR TITLE
Update pingTest targets to include time.apple.com

### DIFF
--- a/src/lib/status-manager.ts
+++ b/src/lib/status-manager.ts
@@ -105,7 +105,7 @@ export class StatusManager {
 
 	private async pingTest (ipVersion: IpFamily) {
 		const packets = config.get<number>('status.numberOfPackets');
-		const targets = [ 'a.gtld-servers.net', 'k.root-servers.net', 'ns1.dns.nl' ];
+		const targets = [ 'a.gtld-servers.net', 'k.root-servers.net', 'time.apple.com' ];
 		const results = await Promise.allSettled(targets.map(target => this.pingCmd({ type: 'ping', ipVersion, target, packets, protocol: 'ICMP', port: 80, inProgressUpdates: false })));
 
 		const rejectedResults: Array<{ target: string; reason: ExecaError }> = [];

--- a/test/unit/lib/status-manager.test.ts
+++ b/test/unit/lib/status-manager.test.ts
@@ -62,10 +62,10 @@ describe('StatusManager', () => {
 		expect(pingCmd.callCount).to.equal(6);
 		expect(pingCmd.args[0]).to.deep.equal([{ type: 'ping', ipVersion: 4, target: 'a.gtld-servers.net', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
 		expect(pingCmd.args[1]).to.deep.equal([{ type: 'ping', ipVersion: 4, target: 'k.root-servers.net', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
-		expect(pingCmd.args[2]).to.deep.equal([{ type: 'ping', ipVersion: 4, target: 'ns1.dns.nl', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
+		expect(pingCmd.args[2]).to.deep.equal([{ type: 'ping', ipVersion: 4, target: 'time.apple.com', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
 		expect(pingCmd.args[3]).to.deep.equal([{ type: 'ping', ipVersion: 6, target: 'a.gtld-servers.net', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
 		expect(pingCmd.args[4]).to.deep.equal([{ type: 'ping', ipVersion: 6, target: 'k.root-servers.net', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
-		expect(pingCmd.args[5]).to.deep.equal([{ type: 'ping', ipVersion: 6, target: 'ns1.dns.nl', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
+		expect(pingCmd.args[5]).to.deep.equal([{ type: 'ping', ipVersion: 6, target: 'time.apple.com', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
 		expect(statusManager.getStatus()).to.equal('ping-test-failed');
 		expect(socket.emit.callCount).to.equal(3);
 		expect(socket.emit.args[0]).to.deep.equal([ 'probe:status:update', 'ping-test-failed' ]);
@@ -135,10 +135,10 @@ describe('StatusManager', () => {
 		expect(pingCmd.callCount).to.equal(6);
 		expect(pingCmd.args[0]).to.deep.equal([{ type: 'ping', ipVersion: 4, target: 'a.gtld-servers.net', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
 		expect(pingCmd.args[1]).to.deep.equal([{ type: 'ping', ipVersion: 4, target: 'k.root-servers.net', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
-		expect(pingCmd.args[2]).to.deep.equal([{ type: 'ping', ipVersion: 4, target: 'ns1.dns.nl', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
+		expect(pingCmd.args[2]).to.deep.equal([{ type: 'ping', ipVersion: 4, target: 'time.apple.com', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
 		expect(pingCmd.args[3]).to.deep.equal([{ type: 'ping', ipVersion: 6, target: 'a.gtld-servers.net', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
 		expect(pingCmd.args[4]).to.deep.equal([{ type: 'ping', ipVersion: 6, target: 'k.root-servers.net', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
-		expect(pingCmd.args[5]).to.deep.equal([{ type: 'ping', ipVersion: 6, target: 'ns1.dns.nl', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
+		expect(pingCmd.args[5]).to.deep.equal([{ type: 'ping', ipVersion: 6, target: 'time.apple.com', packets: 6, protocol: 'ICMP', port: 80, inProgressUpdates: false }]);
 		expect(statusManager.getStatus()).to.equal('ready');
 		expect(socket.emit.callCount).to.equal(3);
 		expect(socket.emit.args[0]).to.deep.equal([ 'probe:status:update', 'ready' ]);


### PR DESCRIPTION
Did some tests and time.apple.com performs better in China. It should bring back some Chinese probes that are down due to QA failing. Most fails were coming from often dns.nl packet loss.