### PR TITLE
fix: handle objects and long messages in API log transport

### DIFF
--- a/src/lib/api-logs-transport.ts
+++ b/src/lib/api-logs-transport.ts
@@ -1,8 +1,7 @@
 import Transport from 'winston-transport';
 import { Socket } from 'socket.io-client';
-import { Logger } from 'winston';
+import { Logger, Logform } from 'winston';
 import { getWinstonMessageContent } from './logger.js';
-import * as winston from 'winston';
 
 export type ApiTransportSettings = {
 	isActive?: boolean;
@@ -39,7 +38,7 @@ class ApiLogsTransport extends Transport {
 		this.scheduleSend();
 	}
 
-	override log (info: winston.Logform.TransformableInfo, callback?: () => void) {
+	override log (info: Logform.TransformableInfo, callback?: () => void) {
 		setImmediate(() => this.emit('logged', info));
 
 		const { timestamp, level, scope } = info;

--- a/src/lib/api-logs-transport.ts
+++ b/src/lib/api-logs-transport.ts
@@ -1,6 +1,8 @@
 import Transport from 'winston-transport';
 import { Socket } from 'socket.io-client';
 import { Logger } from 'winston';
+import { getWinstonMessageContent } from './logger.js';
+import * as winston from 'winston';
 
 export type ApiTransportSettings = {
 	isActive?: boolean;
@@ -10,7 +12,7 @@ export type ApiTransportSettings = {
 
 export type ApiTransportOptions = Transport.TransportStreamOptions & ApiTransportSettings & { socket?: Socket };
 
-type Info = {
+type TransportInfo = {
 	message: string;
 	timestamp: string;
 	level: string;
@@ -18,12 +20,13 @@ type Info = {
 };
 
 class ApiLogsTransport extends Transport {
+	public static readonly MAX_MESSAGE_LEN = 8192;
 	private logger: Logger | undefined;
 	private socket: Socket | undefined;
 	private isActive: boolean;
 	private sendInterval: number;
 	private maxBufferSize: number;
-	private logBuffer: Info[] = [];
+	private logBuffer: TransportInfo[] = [];
 	private droppedLogs: number = 0;
 	private timer: NodeJS.Timeout | undefined = undefined;
 
@@ -36,10 +39,14 @@ class ApiLogsTransport extends Transport {
 		this.scheduleSend();
 	}
 
-	override log (info: Info, callback?: () => void) {
+	override log (info: winston.Logform.TransformableInfo, callback?: () => void) {
 		setImmediate(() => this.emit('logged', info));
 
-		this.logBuffer.push(info);
+		const { timestamp, level, scope } = info;
+		let message = getWinstonMessageContent(info);
+		message = message.length > ApiLogsTransport.MAX_MESSAGE_LEN ? `${message.slice(0, ApiLogsTransport.MAX_MESSAGE_LEN - 3)}...` : message;
+
+		this.logBuffer.push({ message, level, timestamp: timestamp as string, scope: scope as string });
 		const bufferLength = this.logBuffer.length;
 		const bufferOverflow = bufferLength - this.maxBufferSize;
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -24,7 +24,7 @@ const objectFormatter = (object: Record<string, any>) => {
 
 export const getWinstonMessageContent = (info: Partial<winston.Logform.TransformableInfo>) => {
 	const { timestamp, level, scope, message, stack, ...otherFields } = info;
-	let result = String(message);
+	let result = typeof message === 'object' && message !== null ? objectFormatter(message) : String(message);
 
 	if (Object.keys(otherFields).length > 0) {
 		result += `\n${objectFormatter(otherFields)}`;

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -22,24 +22,31 @@ const objectFormatter = (object: Record<string, any>) => {
 	return inspect(objectWithoutSymbols);
 };
 
+export const getWinstonMessageContent = (info: Partial<winston.Logform.TransformableInfo>) => {
+	const { timestamp, level, scope, message, stack, ...otherFields } = info;
+	let result = String(message);
+
+	if (Object.keys(otherFields).length > 0) {
+		result += `\n${objectFormatter(otherFields)}`;
+	}
+
+	if (stack) {
+		result += `\n${info['stack'] as string}`;
+	}
+
+	return result;
+};
+
 const logger = winston.createLogger({
 	level: process.env['LOG_LEVEL'] ?? 'debug',
 	format: winston.format.combine(
 		winston.format.timestamp({ format: 'YYYY-MM-DD HH:mm:ss Z' }),
 		winston.format.prettyPrint(),
 		winston.format.printf((info: winston.Logform.TransformableInfo) => {
-			const { timestamp, level, scope, message, stack, ...otherFields } = info;
-			let result = `[${timestamp as string}] [${level.toUpperCase()}] [${scope as string}] ${message as string}`;
+			const { timestamp, level, scope } = info;
+			const message = getWinstonMessageContent(info);
 
-			if (Object.keys(otherFields).length > 0) {
-				result += `\n${objectFormatter(otherFields)}`;
-			}
-
-			if (stack) {
-				result += `\n${info['stack'] as string}`;
-			}
-
-			return result;
+			return `[${timestamp as string}] [${level.toUpperCase()}] [${scope as string}] ${message}`;
 		}),
 	),
 	transports: [

--- a/test/unit/lib/api-logs-transport.test.ts
+++ b/test/unit/lib/api-logs-transport.test.ts
@@ -4,7 +4,6 @@ import * as winston from 'winston';
 import ApiLogsTransport, { type ApiTransportOptions } from '../../../src/lib/api-logs-transport.js';
 import { Socket } from 'socket.io-client';
 import { useSandboxWithFakeTimers } from '../../utils.js';
-import { getWinstonMessageContent } from '../../../src/lib/logger.js';
 
 describe('ApiLogsTransport', () => {
 	let sandbox: sinon.SinonSandbox;
@@ -280,8 +279,10 @@ describe('ApiLogsTransport', () => {
 
 			const payload = socket.emitWithAck.firstCall.args[1];
 			expect(payload.logs).to.have.lengthOf(2);
-			expect(payload.logs[0]).to.have.property('message', getWinstonMessageContent({ message: obj }));
-			expect(payload.logs[1]).to.have.property('message', getWinstonMessageContent({ message: 'with message', ...obj }));
+			expect(payload.logs[0]).to.have.keys('message', 'level', 'scope', 'timestamp');
+			expect(payload.logs[0]).to.have.property('message', `{ test: 'test', arr: [ 1, 2, { x: 'abc' } ] }`);
+			expect(payload.logs[1]).to.have.keys('message', 'level', 'scope', 'timestamp');
+			expect(payload.logs[1]).to.have.property('message', `with message\n{ test: 'test', arr: [ 1, 2, { x: 'abc' } ] }`);
 		});
 
 		it('should send logs periodically', async () => {

--- a/test/unit/lib/api-logs-transport.test.ts
+++ b/test/unit/lib/api-logs-transport.test.ts
@@ -257,7 +257,7 @@ describe('ApiLogsTransport', () => {
 		it('should trim long messages', async () => {
 			const { logger } = createTransportAndLogger({ isActive: true, sendInterval: 100 });
 
-			const sent = Array(ApiLogsTransport.MAX_MESSAGE_LEN + 10).fill('0').join('');
+			const sent = '0'.repeat(ApiLogsTransport.MAX_MESSAGE_LEN + 10);
 			const expected = sent.slice(0, ApiLogsTransport.MAX_MESSAGE_LEN - 3) + '...';
 
 			logger.info(sent);


### PR DESCRIPTION
Closes #325 