### PR TITLE
fix: use additional update fallbacks

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -17,14 +17,15 @@ function try_update() {
 		echo "Probe version successfully fetched from jsDelivr API."
 		latestVersion=$(jq -r ".version" <<<"${response}" | sed 's/v//')
 	else
-		echo "Probe version check failed. Trying raw.githubusercontent.com..."
+		echo "Failed to fetch the version info from jsDelivr API. Trying GitHub API..."
 		response=$(curl --max-time 40 --retry 3 --retry-max-time 120 --retry-all-errors -XGET -Lf -sS "https://api.github.com/repos/jsdelivr/globalping-probe/releases/latest")
 
 		# Check if the fallback curl succeeded AND returned a non-empty response
 		if [ $? == 0 ] && [ -n "$response" ]; then
-			echo "Probe version successfully fetched from GitHub."
+			echo "Probe version successfully fetched from GitHub API."
 			latestVersion=$(jq -r ".tag_name" <<<"${response}" | sed 's/v//')
 		else
+			echo "Failed to fetch the version info from GitHub API. All methods failed. Exiting."
 			return
 		fi
 	fi


### PR DESCRIPTION
- Added "exec" so that node gets pid1 and `docker stop` applies to node and not bash
- Added retries to our data API. It crashes from time to time and I dont want that to affect our probes
- Added github as last fallback. Mainly cause we had issues where jsdelivr.net was blocked in certain countries