### PR TITLE
fix: adjust socket reconnection delays

### DIFF
--- a/src/helper/api-error-handler.ts
+++ b/src/helper/api-error-handler.ts
@@ -49,7 +49,7 @@ class ErrorHandler {
 			logger.error('Retrying in 1 minute. Probe temporarily disconnected.');
 			setTimeout(() => this.socket.connect(), 60 * 1000);
 		} else {
-			setTimeout(() => this.socket.connect(), 1000);
+			setTimeout(() => this.socket.connect(), 2000);
 		}
 	};
 
@@ -57,7 +57,7 @@ class ErrorHandler {
 		logger.debug(`Disconnected from API: (${reason}).`);
 
 		if (reason === 'io server disconnect') {
-			this.socket.connect();
+			setTimeout(() => this.socket.connect(), 2000);
 		}
 	};
 }

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -86,9 +86,9 @@ function connect (workerId?: number) {
 
 	const socket = io(`${config.get<string>('api.host')}/probes`, {
 		transports: [ 'websocket' ],
-		reconnectionDelay: 2000,
+		reconnectionDelay: 4000,
 		reconnectionDelayMax: 8000,
-		randomizationFactor: 0.75,
+		randomizationFactor: 0.5,
 		query: {
 			version: VERSION,
 			nodeVersion: process.version,

--- a/test/unit/probe.test.ts
+++ b/test/unit/probe.test.ts
@@ -114,9 +114,9 @@ describe('index module', () => {
 
 		expect(ioStub.firstCall.args[1]).to.deep.include({
 			transports: [ 'websocket' ],
-			reconnectionDelay: 2000,
+			reconnectionDelay: 4000,
 			reconnectionDelayMax: 8000,
-			randomizationFactor: 0.75,
+			randomizationFactor: 0.5,
 		});
 
 		expect(ioStub.firstCall.args[1].query.version).to.match(/^\d+.\d+.\d+$/);
@@ -198,6 +198,7 @@ describe('index module', () => {
 		mockSocket.emit('disconnect');
 		expect(connectStub.notCalled).to.be.true;
 		mockSocket.emit('disconnect', 'io server disconnect');
+		sandbox.clock.tick(2000 + 50);
 		expect(connectStub.calledOnce).to.be.true;
 	});
 
@@ -225,13 +226,13 @@ describe('index module', () => {
 		expect(connectStub.callCount).to.equal(1);
 	});
 
-	it('should reconnect after 1 second delay on "connect_error" with other messages', async () => {
+	it('should reconnect after 2 seconds delay on "connect_error" with other messages', async () => {
 		await import('../../src/probe.js');
 
 		mockSocket.emit('connect_error', new Error('some message'));
 
 		expect(connectStub.callCount).to.equal(0);
-		sandbox.clock.tick(1000 + 50);
+		sandbox.clock.tick(2000 + 50);
 		expect(connectStub.callCount).to.equal(1);
 	});
 


### PR DESCRIPTION
After closer review, I found the concurrent IP limit errors on the API side are most likely not caused by restarts directly, as:
1) The synced list logic should prevent it, even in case of unexpected crashes.
2) The errors are distributed over several minutes, which hints at our manual [reconnect](https://github.com/jsdelivr/globalping/blob/bd88b14c7477773265ecddbbe920bec26db677d8/src/lib/ws/helper/reconnect-probes.ts#L14) logic.

The error also affects almost exclusively EU probes, so I suspect a race condition in socket.io (or our usage of it), where the probe reconnects so quickly that the old socket is still in the list (as the disconnect is "soft", meaning there's a 2-way communication before the server removes the socket). And indeed, the reconnection in this case was handled manually by us with no delay, so the disconnect/connect events fired at almost the same time.

This sets the minimum delay to 2 seconds for all cases, with the default reconnection logic using an interval of 2s - 6s instead of 0.5s - 3.5s.