### PR TITLE
fix: avoid split surrogate in http body truncation

### DIFF
--- a/src/command/handlers/http/truncate-headers.ts
+++ b/src/command/handlers/http/truncate-headers.ts
@@ -1,3 +1,5 @@
+import { truncateToWellFormedString } from './truncate-string.js';
+
 const HEADERS_SIZE_LIMIT = 10_000;
 const HEADER_TRUNCATION_MARK = '...[truncated]';
 const RAW_HEADERS_EXTRA_SYMBOLS_SIZE = 3; // ": " between key and value + "\n" line separator.
@@ -87,7 +89,7 @@ export function truncateHeaderPairs (pairs: [string, string][]): TruncateHeaderP
 	cap = Math.max(cap, HEADER_TRUNCATION_MARK.length);
 
 	const headers = kept.map(([ k, v ]): [string, string] => v.length > cap
-		? [ k, v.substring(0, cap - HEADER_TRUNCATION_MARK.length) + HEADER_TRUNCATION_MARK ]
+		? [ k, truncateToWellFormedString(v, cap - HEADER_TRUNCATION_MARK.length) + HEADER_TRUNCATION_MARK ]
 		: [ k, v ]);
 
 	return { truncated: true, headers };

--- a/src/command/handlers/http/truncate-string.ts
+++ b/src/command/handlers/http/truncate-string.ts
@@ -1,0 +1,14 @@
+export const truncateToWellFormedString = (value: string, maxLength: number): string => {
+	if (maxLength <= 0) {
+		return '';
+	}
+
+	let truncated = value.substring(0, maxLength);
+	const lastCode = truncated.charCodeAt(truncated.length - 1);
+
+	if (lastCode >= 0xD800 && lastCode <= 0xDBFF) {
+		truncated = truncated.substring(0, truncated.length - 1);
+	}
+
+	return truncated;
+};

--- a/src/command/handlers/http/undici.ts
+++ b/src/command/handlers/http/undici.ts
@@ -12,6 +12,7 @@ import { dnsLookup } from '../shared/dns-resolver.js';
 import { callbackify } from '../../../lib/util.js';
 import { isIpPrivate } from '../../../lib/private-ip.js';
 import { truncateHeaderPairs } from './truncate-headers.js';
+import { truncateToWellFormedString } from './truncate-string.js';
 
 type TlsDetails = {
 	authorized: boolean;
@@ -367,7 +368,7 @@ export class HttpHandler {
 		let dataString = chunk.toString();
 
 		if (dataString.length > remaining) {
-			dataString = dataString.substring(0, remaining);
+			dataString = truncateToWellFormedString(dataString, remaining);
 			this.result.rawBody += dataString;
 			this.result.truncated = true;
 			this.pushProgress(isFirstMessage, dataString);

--- a/test/unit/command/handlers/http/truncate-headers.test.ts
+++ b/test/unit/command/handlers/http/truncate-headers.test.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { truncateHeaderPairs } from '../../../../../src/command/handlers/http/truncate-headers.js';
+import { hasLoneSurrogate } from '../../../../utils.js';
 
 const repeat = (char: string, n: number) => char.repeat(n);
 
@@ -33,6 +34,23 @@ describe('truncateHeaderPairs', () => {
 			expect(sumChars(result.headers)).to.equal(10_000);
 			expect(result.headers[0]![1].endsWith('...[truncated]')).to.equal(true);
 			expect(result.headers[0]![1].length).to.equal(10_000 - 'x-huge'.length - 2);
+		});
+
+		it('does not split a surrogate pair when truncating an oversized value', () => {
+			const pairs: [string, string][] = [
+				[ 'x-huge', repeat('a', 9966) + '😀' + repeat('c', 20) ],
+				[ 'x-small', 'b' ],
+			];
+
+			const result = truncateHeaderPairs(pairs);
+			const value = result.headers[0]![1];
+
+			expect(result.truncated).to.equal(true);
+			expect(sumChars(result.headers)).to.equal(9999);
+			expect(value.endsWith('...[truncated]')).to.equal(true);
+			expect(hasLoneSurrogate(value)).to.equal(false);
+			expect(JSON.stringify(result.headers)).not.to.include('\\ud83d');
+			expect(JSON.stringify(result.headers)).not.to.include('\\ude00');
 		});
 
 		it('keeps small values untouched while truncating one giant', () => {

--- a/test/unit/command/http-command.test.ts
+++ b/test/unit/command/http-command.test.ts
@@ -7,7 +7,7 @@ import * as sinon from 'sinon';
 import { Socket } from 'socket.io-client';
 import { HttpCommand } from '../../../src/command/http-command.js';
 import { HttpHandler } from '../../../src/command/handlers/http/undici.js';
-import { useSandboxWithFakeTimers } from '../../utils.js';
+import { hasLoneSurrogate, useSandboxWithFakeTimers } from '../../utils.js';
 
 describe('url builder', () => {
 	const buffer = {} as any;
@@ -827,6 +827,65 @@ describe(`.run() method`, () => {
 		expect(result.truncated).to.be.true;
 		expect(result.rawBody).to.have.lengthOf(10000);
 		expect(result.rawBody).to.equal('x'.repeat(10000));
+	});
+
+	it('should not split a surrogate pair when truncating the final response body', async () => {
+		mockHttpResponse([
+			'HTTP/1.1 200 OK',
+			'test: abc',
+			'',
+			'a'.repeat(9999) + '😀',
+		]);
+
+		await new HttpCommand().run(mockedSocket as any, 'measurement', 'test', {
+			type: 'http' as const,
+			target: 'cdn.jsdelivr.net',
+			inProgressUpdates: false,
+			protocol: 'HTTP',
+			request: { method: 'GET', path: '/npm/jquery', query: '' },
+			ipVersion: 4,
+		});
+
+		const result = mockedSocket.emit.lastCall.args[1].result;
+
+		expect(result.rawBody.length).to.equal(9999);
+		expect(result.rawOutput.length).to.equal(10023);
+		expect(result.truncated).to.equal(true);
+		expect(hasLoneSurrogate(result.rawBody)).to.equal(false);
+		expect(hasLoneSurrogate(result.rawOutput)).to.equal(false);
+		expect(JSON.stringify(result)).not.to.include('\\ud83d');
+		expect(JSON.stringify(result)).not.to.include('\\ude00');
+	});
+
+	it('should not split a surrogate pair when truncating in-progress response body updates', async () => {
+		mockHttpResponse([
+			'HTTP/1.1 200 OK',
+			'test: abc',
+			'',
+			'a'.repeat(9999) + '😀',
+		]);
+
+		await new HttpCommand().run(mockedSocket as any, 'measurement', 'test', {
+			type: 'http' as const,
+			target: 'cdn.jsdelivr.net',
+			inProgressUpdates: true,
+			protocol: 'HTTP',
+			request: { method: 'GET', path: '/npm/jquery', query: '' },
+			ipVersion: 4,
+		});
+
+		const progress = mockedSocket.emit.firstCall.args[1].result;
+		const result = mockedSocket.emit.lastCall.args[1].result;
+
+		expect(progress.rawBody.length).to.equal(9999);
+		expect(progress.rawOutput.length).to.equal(10023);
+		expect(result.rawBody.length).to.equal(9999);
+		expect(result.rawOutput.length).to.equal(10023);
+		expect(result.truncated).to.equal(true);
+		expect(hasLoneSurrogate(progress.rawBody)).to.equal(false);
+		expect(hasLoneSurrogate(progress.rawOutput)).to.equal(false);
+		expect(hasLoneSurrogate(result.rawBody)).to.equal(false);
+		expect(hasLoneSurrogate(result.rawOutput)).to.equal(false);
 	});
 
 	it('should set truncated=true when response headers exceed the size limit', async () => {

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -19,6 +19,7 @@ const progressIntervalTime = config.get<number>('commands.progressInterval');
 
 export const getCmdMock = (name: string): string => readFileSync(path.resolve(`./test/mocks/${name}.txt`)).toString().replace(/\r?\n$/, '');
 export const getCmdMockResult = (name: string) => JSON.parse(readFileSync(path.resolve(`./test/mocks/${name}.json`)).toString()) as Record<string, unknown>;
+export const hasLoneSurrogate = (value: string): boolean => /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(value);
 
 export class MockSocket extends EventEmitter {
 	override emit (event: string, data?: any, callback?: () => void) {


### PR DESCRIPTION
Fixes HTTP response body truncation, so the probe no longer emits malformed UTF-16 when the 10,000-character cutoff falls within a surrogate pair.