### PR TITLE
ci: skip Docker registry login when not publishing

### DIFF
--- a/.github/workflows/_docker.yaml
+++ b/.github/workflows/_docker.yaml
@@ -50,6 +50,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log to Docker Hub
+        # Only needed when pushing. On PRs (publish=false) the secret is absent
+        # (forks never receive secrets), so skip login and just build the image.
+        if: ${{ inputs.publish }}
         uses: docker/login-action@v3
         with:
           username: jimaek
@@ -74,6 +77,7 @@ jobs:
             node_env=production
 
       - name: Log to ghcr.io
+        if: ${{ inputs.publish }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Problem

The reusable `_docker.yaml` workflow is invoked from `ci.yaml` with `publish: false` to validate that the image builds on every push/PR. However, the **Docker Hub** and **ghcr.io** login steps run unconditionally, and the Docker Hub login requires `secrets.DOCKERHUB_TOKEN`.

GitHub never exposes repository secrets to pull requests from forks, so on any fork PR the secret is empty and the `Test docker` job fails immediately at the login step:

```
Run docker/login-action@v3
Error: Password required
```

…before the image is even built. This makes the `Test docker` check red on every external contribution (e.g. #368).

## Fix

Gate both login steps on `inputs.publish`. The login is only needed in order to **push**:

- **CI runs** (`publish: false`): skip login, just build the image (`push: false` already) → the job passes without needing any secret, and still validates that the Dockerfile builds for all target platforms.
- **Release runs** (`publish: true`): log in and push exactly as before — unchanged.

## Testing

The `build-push-action` steps already use `push: ${{ inputs.publish }}`, so they build-only on PRs regardless; this change just removes the now-unnecessary login that was the sole cause of the failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)