### PR TITLE
feat: add RAM warning

### DIFF
--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -60,6 +60,11 @@ function try_update() {
 
 			availableDiskSpaceMb=$(df --block-size=MB --output=avail / | tail -1 | tr -dc '0-9')
 
+			if [ -z "$availableDiskSpaceMb" ]; then
+				echo "Failed to determine the available disk space. Skipping the update."
+				return
+			fi
+
 			if [ "$availableDiskSpaceMb" -lt "$UPDATE_MIN_DISK_SPACE_MB" ]; then
 				echo "
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -61,7 +61,7 @@ function try_update() {
 			availableDiskSpaceMb=$(df --block-size=MB --output=avail / | tail -1 | tr -dc '0-9')
 
 			if [ -z "$availableDiskSpaceMb" ]; then
-				echo "Failed to determine the available disk space. Skipping the update."
+				echo "Failed to determine available disk space. Skipping the update."
 				return
 			fi
 
@@ -70,8 +70,8 @@ function try_update() {
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @      WARNING: LOW DISK SPACE, SKIPPING THE UPDATE       @
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-Only ${availableDiskSpaceMb}MB of disk space is available (minimum ${UPDATE_MIN_DISK_SPACE_MB}MB required to download an update).
-Skipping the update. Please increase the available disk size.
+Only ${availableDiskSpaceMb} MB of disk space is available. At least ${UPDATE_MIN_DISK_SPACE_MB} MB is required for the update.
+Please increase the available disk space.
 "
 				return
 			fi

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -2,6 +2,8 @@
 
 update-ca-certificates
 
+UPDATE_MIN_DISK_SPACE_MB=200
+
 function run_probe() {
 	exec node /app/dist/index.js
 	return
@@ -55,6 +57,19 @@ function try_update() {
 			loadedTarball="globalping-probe-${latestVersion}"
 
 			echo "Starting self-update process to v$latestVersion..."
+
+			availableDiskSpaceMb=$(df --block-size=MB --output=avail / | tail -1 | tr -dc '0-9')
+
+			if [ "$availableDiskSpaceMb" -lt "$UPDATE_MIN_DISK_SPACE_MB" ]; then
+				echo "
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@      WARNING: LOW DISK SPACE, SKIPPING THE UPDATE       @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+Only ${availableDiskSpaceMb}MB of disk space is available (minimum ${UPDATE_MIN_DISK_SPACE_MB}MB required to download an update).
+Skipping the update. Please increase the available disk size.
+"
+				return
+			fi
 
 			curl -XGET -Lf -sS "${latestBundleA}" -o "/tmp/${loadedTarball}.tar.gz"
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ function updateNode () {
 	console.log(`[${new Date().toISOString()}] Wanted node.js version ${WANTED_VERSION}`);
 
 	const isNodeUpToDate = process.version === WANTED_VERSION;
-	const memory = process.constrainedMemory?.() || os.totalmem();
+	const memory = Math.min(process.constrainedMemory?.() || Infinity, os.totalmem());
 	const disk = getAvailableDiskSpace();
 	const hasMemory = memory >= MIN_NODE_UPDATE_MEMORY;
 	const hasDisk = disk >= MIN_NODE_UPDATE_DISK_SPACE_MB;

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,11 +155,11 @@ function getLines (stats: ResourceStats) {
 	const lines = [];
 
 	if (!stats.hasMemory) {
-		lines.push(`  Memory: ${Math.round(stats.memory / 1e6)} MB total (minimum ${MIN_NODE_UPDATE_MEMORY / 1e6} MB required)`);
+		lines.push(`  Memory: ${Math.round(stats.memory / 1e6)}MB total (minimum ${MIN_NODE_UPDATE_MEMORY / 1e6}MB required)`);
 	}
 
 	if (!stats.hasDisk) {
-		lines.push(`  Disk: ${stats.disk} MB available (minimum ${MIN_NODE_UPDATE_DISK_SPACE_MB} MB required)`);
+		lines.push(`  Disk: ${stats.disk}MB available (minimum ${MIN_NODE_UPDATE_DISK_SPACE_MB}MB required)`);
 	}
 
 	return lines.join('\n');

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ function updateNode () {
 	console.log(`[${new Date().toISOString()}] Wanted node.js version ${WANTED_VERSION}`);
 
 	const isNodeUpToDate = process.version === WANTED_VERSION;
-	const memory = os.totalmem();
+	const memory = process.constrainedMemory?.() || os.totalmem();
 	const disk = getAvailableDiskSpace();
 	const hasMemory = memory >= MIN_NODE_UPDATE_MEMORY;
 	const hasDisk = disk >= MIN_NODE_UPDATE_DISK_SPACE_MB;

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ function updateNode () {
 		}
 
 		if (!hasResources) {
-			console.log(`[${new Date().toISOString()}] Resources are below the required threshold. Not updating.`);
+			console.log(`[${new Date().toISOString()}] Insufficient resources for auto-update. Not updating.`);
 			logUpdateContainerMessage({ memory, disk, hasMemory, hasDisk });
 			return;
 		}
@@ -155,25 +155,32 @@ function getLines (stats: ResourceStats) {
 	const lines = [];
 
 	if (!stats.hasMemory) {
-		lines.push(`  Memory: ${Math.round(stats.memory / 1e6)}MB total (minimum ${MIN_NODE_UPDATE_MEMORY / 1e6}MB required)`);
+		lines.push(`  Memory: ${Math.round(stats.memory / 1e6)} MB is available to the probe. At least ${MIN_NODE_UPDATE_MEMORY / 1e6} MB is required.`);
 	}
 
 	if (!stats.hasDisk) {
-		lines.push(`  Disk: ${stats.disk}MB available (minimum ${MIN_NODE_UPDATE_DISK_SPACE_MB}MB required)`);
+		lines.push(`  Disk: ${stats.disk} MB is available. At least ${MIN_NODE_UPDATE_DISK_SPACE_MB} MB is required.`);
 	}
 
 	return lines.join('\n');
 }
 
+function getResourceIncreaseText (stats: ResourceStats) {
+	return [
+		!stats.hasMemory && `RAM to at least ${(MIN_NODE_UPDATE_MEMORY / 1e6) * 2} MB`,
+		!stats.hasDisk && `disk space to at least ${MIN_NODE_UPDATE_DISK_SPACE_MB} MB`,
+	].filter(Boolean).join(' and ');
+}
+
 function logLowResourcesMessage (stats: ResourceStats) {
 	console.log(`
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-@      WARNING: LOW RESOURCES, AUTO-UPDATES WILL FAIL     @
+@      WARNING: LOW RESOURCES, AUTO-UPDATES DISABLED      @
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-This probe is below the resources needed to run auto-updates.
-It will stop working once a new version is released.
+This probe does not meet the minimum resource requirements for automatic updates.
+It may stop working after a new version is released.
 ${getLines(stats)}
-Please increase the available ${[ !stats.hasMemory && `RAM to >= ${(MIN_NODE_UPDATE_MEMORY / 1e6) * 2}MB`, !stats.hasDisk && `disk size to >= ${MIN_NODE_UPDATE_DISK_SPACE_MB}MB` ].filter(Boolean).join(' and ')}.
+Please increase ${getResourceIncreaseText(stats)}.
 	`);
 
 	setTimeout(() => logLowResourcesMessage(stats), 10 * 60 * 1000);
@@ -184,11 +191,11 @@ function logUpdateContainerMessage (stats: ResourceStats) {
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @     WARNING: PROBE CONTAINER OUTDATED, PLEASE UPDATE    @
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-Current probe container is out of date and we couldn't update it automatically.
+The current probe container is out of date, and it could not be updated automatically.
 ${getLines(stats)}
 Please either:
 - update it manually: https://github.com/jsdelivr/globalping-probe#optional-container-update
-- increase the available ${[ !stats.hasMemory && `RAM to >= ${(MIN_NODE_UPDATE_MEMORY / 1e6) * 2}MB`, !stats.hasDisk && `disk size to >= ${MIN_NODE_UPDATE_DISK_SPACE_MB}MB` ].filter(Boolean).join(' and ')}
+- increase ${getResourceIncreaseText(stats)}
 	`);
 
 	setTimeout(() => logUpdateContainerMessage(stats), 10 * 60 * 1000);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,13 @@ const MIN_NODE_UPDATE_DISK_SPACE_MB = 1000;
 const dirname = path.dirname(fileURLToPath(import.meta.url));
 const UUID_FILE = `/.globalping-probe-uuid`;
 
+type ResourceStats = {
+	memory: number;
+	disk: number;
+	hasMemory: boolean;
+	hasDisk: boolean;
+};
+
 function updateEntrypoint () {
 	const currentEntrypointPath = path.join(dirname, '../../entrypoint.sh');
 	const newEntrypointPath = path.join(dirname, '../bin/entrypoint.sh');
@@ -42,25 +49,29 @@ function updateNode () {
 	console.log(`[${new Date().toISOString()}] Current node.js version ${process.version}`);
 	console.log(`[${new Date().toISOString()}] Wanted node.js version ${WANTED_VERSION}`);
 
-	if (process.version === WANTED_VERSION) {
+	const isNodeUpToDate = process.version === WANTED_VERSION;
+	const memory = os.totalmem();
+	const disk = getAvailableDiskSpace();
+	const hasMemory = memory >= MIN_NODE_UPDATE_MEMORY;
+	const hasDisk = disk >= MIN_NODE_UPDATE_DISK_SPACE_MB;
+	const hasResources = hasMemory && hasDisk;
+	const isHwProbe = process.env['GP_HOST_HW'] || looksLikeV1HardwareDevice();
+
+	if (isNodeUpToDate) {
+		!isHwProbe && !hasResources && logLowResourcesMessage({ memory, disk, hasMemory, hasDisk });
 		return;
 	}
 
 	try {
-		const IS_HW_PROBE = process.env['GP_HOST_HW'] || looksLikeV1HardwareDevice();
-
-		if (IS_HW_PROBE) {
+		if (isHwProbe) {
 			console.log(`[${new Date().toISOString()}] Hardware probe detected. Not updating.`);
 			logUpdateFirmwareMessage();
 			return;
 		}
 
-		const PROBE_MEMORY = os.totalmem();
-		const PROBE_DISK_SPACE_MB = getAvailableDiskSpace();
-
-		if (PROBE_MEMORY < MIN_NODE_UPDATE_MEMORY || PROBE_DISK_SPACE_MB < MIN_NODE_UPDATE_DISK_SPACE_MB) {
-			console.log(`[${new Date().toISOString()}] Total system memory (${PROBE_MEMORY}) or disk space (${PROBE_DISK_SPACE_MB}MB} below the required threshold. Not updating.`);
-			logUpdateContainerMessage();
+		if (!hasResources) {
+			console.log(`[${new Date().toISOString()}] Resources are below the required threshold. Not updating.`);
+			logUpdateContainerMessage({ memory, disk, hasMemory, hasDisk });
 			return;
 		}
 
@@ -140,18 +151,47 @@ https://github.com/jsdelivr/globalping-hwprobe#download-the-latest-firmware
 	setTimeout(logUpdateFirmwareMessage, 10 * 60 * 1000);
 }
 
-function logUpdateContainerMessage () {
+function getLines (stats: ResourceStats) {
+	const lines = [];
+
+	if (!stats.hasMemory) {
+		lines.push(`  Memory: ${Math.round(stats.memory / 1e6)} MB total (minimum ${MIN_NODE_UPDATE_MEMORY / 1e6} MB required)`);
+	}
+
+	if (!stats.hasDisk) {
+		lines.push(`  Disk: ${stats.disk} MB available (minimum ${MIN_NODE_UPDATE_DISK_SPACE_MB} MB required)`);
+	}
+
+	return lines.join('\n');
+}
+
+function logLowResourcesMessage (stats: ResourceStats) {
+	console.log(`
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@      WARNING: LOW RESOURCES, AUTO-UPDATES WILL FAIL     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+This probe is below the resources needed to run auto-updates.
+It will stop working once a new version is released.
+${getLines(stats)}
+Please increase the available ${[ !stats.hasMemory && `RAM to >= ${(MIN_NODE_UPDATE_MEMORY / 1e6) * 2}MB`, !stats.hasDisk && `disk size to >= ${MIN_NODE_UPDATE_DISK_SPACE_MB}MB` ].filter(Boolean).join(' and ')}.
+	`);
+
+	setTimeout(() => logLowResourcesMessage(stats), 10 * 60 * 1000);
+}
+
+function logUpdateContainerMessage (stats: ResourceStats) {
 	console.log(`
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @     WARNING: PROBE CONTAINER OUTDATED, PLEASE UPDATE    @
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 Current probe container is out of date and we couldn't update it automatically.
+${getLines(stats)}
 Please either:
 - update it manually: https://github.com/jsdelivr/globalping-probe#optional-container-update
-- increase the available RAM to >= 500MB and disk size to >= 1GB
+- increase the available ${[ !stats.hasMemory && `RAM to >= ${(MIN_NODE_UPDATE_MEMORY / 1e6) * 2}MB`, !stats.hasDisk && `disk size to >= ${MIN_NODE_UPDATE_DISK_SPACE_MB}MB` ].filter(Boolean).join(' and ')}
 	`);
 
-	setTimeout(logUpdateContainerMessage, 10 * 60 * 1000);
+	setTimeout(() => logUpdateContainerMessage(stats), 10 * 60 * 1000);
 }
 
 updateEntrypoint();

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -92,7 +92,7 @@ function connect (workerId?: number) {
 		query: {
 			version: VERSION,
 			nodeVersion: process.version,
-			totalMemory: process.constrainedMemory?.() || os.totalmem(),
+			totalMemory: Math.min(process.constrainedMemory?.() || Infinity, os.totalmem()),
 			totalDiskSize: getTotalDiskSize(),
 			availableDiskSpace: getAvailableDiskSpace(),
 			uuid: probeUuid,

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -92,7 +92,7 @@ function connect (workerId?: number) {
 		query: {
 			version: VERSION,
 			nodeVersion: process.version,
-			totalMemory: os.totalmem(),
+			totalMemory: process.constrainedMemory?.() || os.totalmem(),
 			totalDiskSize: getTotalDiskSize(),
 			availableDiskSpace: getAvailableDiskSpace(),
 			uuid: probeUuid,


### PR DESCRIPTION
Fixes https://github.com/jsdelivr/globalping-probe/issues/330

If node is outdated + resources are low, we are logging:
```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@     WARNING: PROBE CONTAINER OUTDATED, PLEASE UPDATE    @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Current probe container is out of date and we couldn't update it automatically.
  Memory: 210MB total (minimum 250MB required)
Please either:
- update it manually: https://github.com/jsdelivr/globalping-probe#optional-container-update
- increase the available RAM to >= 500MB
```
If node is up to date, but resources are low, we are logging:
```
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@      WARNING: LOW RESOURCES, AUTO-UPDATES WILL FAIL     @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
This probe is below the resources needed to run auto-updates.
It will stop working once a new version is released.
  Disk: 868MB available (minimum 1000MB required)
Please increase the available disk size to >= 1000MB.
```