### PR TITLE
fix: allow unknown measurement options

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -11,6 +11,7 @@ import { ProgressBuffer } from '../helper/progress-buffer.js';
 import { scopedLogger } from '../lib/logger.js';
 import { InvalidOptionsException } from './exception/invalid-options-exception.js';
 import { getProcessTimeout } from '../helper/timeout.js';
+import { validateCommandOptions } from '../helper/validate-command-options.js';
 
 import ClassicDigParser from './handlers/dig/classic.js';
 import type {
@@ -112,7 +113,7 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 	constructor (private readonly cmd: typeof dnsCmd) {}
 
 	async run (socket: Socket, measurementId: string, testId: string, options: DnsOptions): Promise<unknown> {
-		const validationResult = dnsOptionsSchema.validate(options);
+		const validationResult = validateCommandOptions(dnsOptionsSchema, options);
 
 		if (validationResult.error) {
 			throw new InvalidOptionsException('dns', validationResult.error);

--- a/src/command/http-command.ts
+++ b/src/command/http-command.ts
@@ -2,6 +2,7 @@ import Joi from 'joi';
 import type { Socket } from 'socket.io-client';
 import type { CommandInterface } from '../types.js';
 import { ProgressBuffer } from '../helper/progress-buffer.js';
+import { validateCommandOptions } from '../helper/validate-command-options.js';
 import { joiValidateIp } from '../lib/private-ip.js';
 import { InvalidOptionsException } from './exception/invalid-options-exception.js';
 import { HttpHandler } from './handlers/http/undici.js';
@@ -57,7 +58,7 @@ export const httpOptionsSchema = Joi.object<HttpOptions>({
 
 export class HttpCommand implements CommandInterface<HttpOptions> {
 	async run (socket: Socket, measurementId: string, testId: string, cmdOptions: HttpOptions): Promise<unknown> {
-		const validationResult = httpOptionsSchema.validate(cmdOptions);
+		const validationResult = validateCommandOptions(httpOptionsSchema, cmdOptions);
 
 		if (validationResult.error) {
 			throw new InvalidOptionsException('http', validationResult.error);

--- a/src/command/mtr-command.ts
+++ b/src/command/mtr-command.ts
@@ -13,6 +13,7 @@ import { getFailureSource, InternalError, isExposed } from '../lib/internal-erro
 import { scopedLogger } from '../lib/logger.js';
 import { InvalidOptionsException } from './exception/invalid-options-exception.js';
 import { getProcessTimeout } from '../helper/timeout.js';
+import { validateCommandOptions } from '../helper/validate-command-options.js';
 
 import type {
 	HopType,
@@ -94,7 +95,7 @@ export class MtrCommand implements CommandInterface<MtrOptions> {
 	constructor (private readonly cmd: typeof mtrCmd, private readonly lookup = cachedDnsLookup) {}
 
 	async run (socket: Socket, measurementId: string, testId: string, options: MtrOptions): Promise<unknown> {
-		const validationResult = mtrOptionsSchema.validate(options);
+		const validationResult = validateCommandOptions(mtrOptionsSchema, options);
 
 		if (validationResult.error) {
 			throw new InvalidOptionsException('mtr', validationResult.error);

--- a/src/command/ping-command.ts
+++ b/src/command/ping-command.ts
@@ -12,6 +12,7 @@ import { InvalidOptionsException } from './exception/invalid-options-exception.j
 import parse, { type PingParseOutput } from './handlers/ping/parse.js';
 import { tcpPing, formatTcpPingResult, TcpPingData } from './handlers/ping/tcp-ping.js';
 import { getPacketInterval, getProcessTimeout } from '../helper/timeout.js';
+import { validateCommandOptions } from '../helper/validate-command-options.js';
 
 export type PingOptions = {
 	type: 'ping';
@@ -108,7 +109,7 @@ export const pingCmd = (options: PingOptions, commandOptions: PingCommandOptions
 
 export class PingCommand implements CommandInterface<PingOptions> {
 	async run (socket: Socket, measurementId: string, testId: string, options: PingOptions): Promise<unknown> {
-		const validationResult = pingOptionsSchema.validate(options);
+		const validationResult = validateCommandOptions(pingOptionsSchema, options);
 
 		if (validationResult.error) {
 			throw new InvalidOptionsException('ping', validationResult.error);

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -9,6 +9,7 @@ import { scopedLogger } from '../lib/logger.js';
 import { byLine } from '../lib/by-line.js';
 import { InvalidOptionsException } from './exception/invalid-options-exception.js';
 import { getProcessTimeout } from '../helper/timeout.js';
+import { validateCommandOptions } from '../helper/validate-command-options.js';
 
 const reHost = /(\S+?)(%\w+)?(\s+)\(((?:\d+\.){3}\d+|[\da-fA-F:]+)(%\w+)?\)/;
 const reRtt = /(\d+(?:\.?\d+)?)\s+ms(!\S*)?/g;
@@ -125,7 +126,7 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 	constructor (private readonly cmd: typeof traceCmd) {}
 
 	async run (socket: Socket, measurementId: string, testId: string, options: TraceOptions): Promise<unknown> {
-		const validationResult = traceOptionsSchema.validate(options);
+		const validationResult = validateCommandOptions(traceOptionsSchema, options);
 
 		if (validationResult.error) {
 			throw new InvalidOptionsException('traceroute', validationResult.error);

--- a/src/helper/validate-command-options.ts
+++ b/src/helper/validate-command-options.ts
@@ -1,0 +1,5 @@
+import Joi from 'joi';
+
+export const validateCommandOptions = <T> (schema: Joi.ObjectSchema<T>, options: unknown) => {
+	return schema.validate(options, { allowUnknown: true });
+};

--- a/test/unit/helper/validate-command-options.test.ts
+++ b/test/unit/helper/validate-command-options.test.ts
@@ -1,0 +1,34 @@
+import { expect } from 'chai';
+import Joi from 'joi';
+import { validateCommandOptions } from '../../../src/helper/validate-command-options.js';
+
+describe('validate command options', () => {
+	it('should allow unknown fields at any nesting level', () => {
+		const schema = Joi.object({
+			type: Joi.string().valid('example').required(),
+			nested: Joi.object({
+				known: Joi.string().required(),
+			}).required(),
+		});
+
+		const result = validateCommandOptions(schema, {
+			type: 'example',
+			futureTopLevelOption: true,
+			nested: {
+				known: 'value',
+				futureNestedOption: true,
+			},
+		});
+
+		expect(result.error).to.equal(undefined);
+
+		expect(result.value).to.deep.equal({
+			type: 'example',
+			futureTopLevelOption: true,
+			nested: {
+				known: 'value',
+				futureNestedOption: true,
+			},
+		});
+	});
+});


### PR DESCRIPTION
We already have a rather loose validation here and rely on the API to send the correct values; this might make future deployments easier.