### PR TITLE
ci: use SSH deploy key for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ jobs:
     container: node:22-bookworm-slim
 
     needs: test
+    environment: release
 
     permissions:
       contents: write
@@ -30,6 +31,8 @@ jobs:
         run: apt update && apt install -y git
 
       - uses: actions/checkout@v7
+        with:
+          ssh-key: ${{ secrets.RELEASE_SSH_KEY }}
 
       - name: Change directory ownership to the node user
         run: chown -R node:node .

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -16,7 +16,7 @@ const releaseNoteTypes = [
 
 module.exports = {
 	branches: [ 'master' ],
-	repositoryUrl: 'https://github.com/jsdelivr/globalping-probe.git',
+	repositoryUrl: 'git@github.com:jsdelivr/globalping-probe.git',
 	plugins: [
 		[ '@semantic-release/commit-analyzer', {
 			releaseRules: [


### PR DESCRIPTION
To enable Rulesets.