### PR TITLE
fix: avoid leading newlines in timeout output

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -177,7 +177,8 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 			if (isExposed(error)) {
 				output = error.message;
 			} else if (isExecaError(error) && error.timedOut) {
-				output = this.rewrite(error.stdout.toString(), cmdOptions.trace) + '\n\nThe measurement command timed out.';
+				output = this.rewrite(error.stdout.toString(), cmdOptions.trace);
+				output += `${output ? '\n\n' : ''}The measurement command timed out.`;
 			} else if (isExecaError(error) && error.stdout.toString().length > 0) {
 				output = this.rewrite(error.stdout.toString(), cmdOptions.trace);
 			} else {

--- a/src/command/mtr-command.ts
+++ b/src/command/mtr-command.ts
@@ -168,7 +168,7 @@ export class MtrCommand implements CommandInterface<MtrOptions> {
 
 			if (isExecaError(error)) {
 				result.rawOutput = error.stdout.toString();
-				error.timedOut && (result.rawOutput += '\n\nThe measurement command timed out.');
+				error.timedOut && (result.rawOutput += `${result.rawOutput ? '\n\n' : ''}The measurement command timed out.`);
 			} else {
 				cmd?.kill('SIGKILL');
 

--- a/src/command/ping-command.ts
+++ b/src/command/ping-command.ts
@@ -171,7 +171,7 @@ export class PingCommand implements CommandInterface<PingOptions> {
 
 				if (error.timedOut) {
 					result.status = 'failed';
-					result.rawOutput += '\n\nThe measurement command timed out.';
+					result.rawOutput += `${result.rawOutput ? '\n\n' : ''}The measurement command timed out.`;
 				}
 
 				!result.rawOutput && (result.rawOutput = 'Test failed. Please try again.');

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -173,7 +173,7 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 
 			if (isExecaError(error)) {
 				output = error.stdout.toString();
-				error.timedOut && (output += '\n\nThe measurement command timed out.');
+				error.timedOut && (output += `${output ? '\n\n' : ''}The measurement command timed out.`);
 			} else {
 				logger.error(error);
 			}

--- a/test/unit/command/dns-command.test.ts
+++ b/test/unit/command/dns-command.test.ts
@@ -1094,7 +1094,7 @@ describe('dns command', () => {
 					result: {
 						status: 'failed',
 						failureSource: 'resolver',
-						rawOutput: '\n\nThe measurement command timed out.',
+						rawOutput: 'The measurement command timed out.',
 						statusCodeName: null,
 						statusCode: null,
 						answers: [],

--- a/test/unit/command/mtr-command.test.ts
+++ b/test/unit/command/mtr-command.test.ts
@@ -653,6 +653,28 @@ describe('mtr command executor', () => {
 			]);
 		});
 
+		it('should not prepend blank lines to a timeout without command output', async () => {
+			const options = {
+				type: 'mtr' as const,
+				timeout: 5,
+				target: 'jsdelivr.net',
+				inProgressUpdates: false,
+				ipVersion: 4,
+			};
+			const mockCmd = getExecaMock();
+			const mtr = new MtrCommand((): any => mockCmd, dnsResolver('1.1.1.1'));
+			const runPromise = mtr.run(mockedSocket as any, 'measurement', 'test', options as MtrOptions);
+			const timeoutError = new Error('Timeout') as ExecaError;
+			timeoutError.stderr = '';
+			timeoutError.stdout = '';
+			timeoutError.timedOut = true;
+			mockCmd.reject(timeoutError);
+
+			await runPromise;
+
+			expect((mockedSocket.emit.lastCall.args[1] as any).result.rawOutput).to.equal('The measurement command timed out.');
+		});
+
 		it('should reject private target on validation', async () => {
 			try {
 				await new MtrCommand((() => {

--- a/test/unit/command/ping-command.test.ts
+++ b/test/unit/command/ping-command.test.ts
@@ -694,6 +694,31 @@ describe('ping command executor', () => {
 			]);
 		});
 
+		it('should not prepend blank lines to a timeout without command output', async () => {
+			const mockedCmd = getExecaMock();
+			const ping = new PingCommand();
+			const options = {
+				type: 'ping' as PingOptions['type'],
+				timeout: 5,
+				target: 'google.com',
+				packets: 3,
+				protocol: 'ICMP',
+				port: 80,
+				inProgressUpdates: false,
+				ipVersion: 4 as const,
+			};
+			const runPromise = ping.runIcmp((): any => mockedCmd, mockedSocket as any, 'measurement', 'test', options);
+			const timeoutError = new Error('Timeout') as ExecaError;
+			timeoutError.stderr = '';
+			timeoutError.stdout = '';
+			timeoutError.timedOut = true;
+			mockedCmd.reject(timeoutError);
+
+			await runPromise;
+
+			expect((mockedSocket.emit.lastCall.args[1] as any).result.rawOutput).to.equal('The measurement command timed out.');
+		});
+
 		it('should reject private target on validation', async () => {
 			try {
 				await new PingCommand().run(mockedSocket as any, 'measurement', 'test', {

--- a/test/unit/command/traceroute-command.test.ts
+++ b/test/unit/command/traceroute-command.test.ts
@@ -412,6 +412,30 @@ describe('trace command', () => {
 				]);
 			});
 
+			it('should not prepend blank lines to a timeout without command output', async () => {
+				const options = {
+					type: 'traceroute' as TraceOptions['type'],
+					timeout: 5,
+					target: 'google.com',
+					port: 53,
+					protocol: 'UDP',
+					inProgressUpdates: false,
+					ipVersion: 4,
+				};
+				const mockCmd = getExecaMock();
+				const traceroute = new TracerouteCommand((): any => mockCmd);
+				const runPromise = traceroute.run(mockSocket as any, 'measurement', 'test', options);
+				const timeoutError = new Error('Timeout') as ExecaError;
+				timeoutError.stderr = '';
+				timeoutError.stdout = '';
+				timeoutError.timedOut = true;
+				mockCmd.reject(timeoutError);
+
+				await runPromise;
+
+				expect((mockSocket.emit.lastCall.args[1] as any).result.rawOutput).to.equal('The measurement command timed out.');
+			});
+
 			for (const { expectedSource, output } of [
 				{ expectedSource: 'target', output: 'traceroute: missing.example: Name or service not known' },
 				{ expectedSource: 'target', output: 'traceroute to example.com (1.1.1.1), 20 hops max\n 1  192.0.2.1  1.0 ms !H' },


### PR DESCRIPTION
Closes https://github.com/jsdelivr/globalping/issues/877.