### PR TITLE
fix: avoid false ping measurement timeouts

### DIFF
--- a/config/default.cjs
+++ b/config/default.cjs
@@ -29,7 +29,7 @@ module.exports = {
 		maxUptime: 604800,
 	},
 	commands: {
-		processGrace: 1,
+		processGrace: 2,
 		progressInterval: 500,
 		ping: {
 			interval: 0.5,

--- a/src/command/ping-command.ts
+++ b/src/command/ping-command.ts
@@ -11,7 +11,7 @@ import { byLine } from '../lib/by-line.js';
 import { InvalidOptionsException } from './exception/invalid-options-exception.js';
 import parse, { type PingParseOutput } from './handlers/ping/parse.js';
 import { tcpPing, formatTcpPingResult, TcpPingData } from './handlers/ping/tcp-ping.js';
-import { getPacketInterval, getProcessTimeout } from '../helper/timeout.js';
+import { getLastPacketTime, getPacketInterval, getProcessTimeout } from '../helper/timeout.js';
 import { validateCommandOptions } from '../helper/validate-command-options.js';
 
 export type PingOptions = {
@@ -89,12 +89,13 @@ const classifyIcmpFailure = (error: unknown, rawOutput: string): FailureSource =
 export const argBuilder = (options: PingOptions, commandOptions: PingCommandOptions = {}): string[] => {
 	const interval = commandOptions.interval ?? config.get<number>('commands.ping.interval');
 	const packetInterval = getPacketInterval(options.packets, options.timeout, interval, config.get<number>('commands.ping.minInterval'));
+	const responseTimeout = options.timeout - 1 - getLastPacketTime(options.packets, packetInterval);
 	const args = [
 		`-${options.ipVersion}`,
 		'-O',
 		[ '-c', options.packets.toString() ],
 		[ '-i', String(packetInterval) ],
-		[ '-w', String(options.timeout) ],
+		[ '-W', String(responseTimeout) ],
 		options.target,
 	].flat();
 

--- a/test/unit/command/mtr-command.test.ts
+++ b/test/unit/command/mtr-command.test.ts
@@ -304,7 +304,7 @@ describe('mtr command executor', () => {
 			await clock.tickAsync(2900);
 
 			expect(passedArgs[passedArgs.indexOf('--interval') + 1]).to.equal('0.2');
-			expect(passedProcessTimeout).to.equal(3100);
+			expect(passedProcessTimeout).to.equal(4100);
 
 			mockCmd.resolve({ stdout: '' });
 			await runPromise;
@@ -591,7 +591,7 @@ describe('mtr command executor', () => {
 			await runPromise;
 
 			expect(passedTarget).to.equal('1.1.1.1');
-			expect(passedProcessTimeout).to.equal(6000);
+			expect(passedProcessTimeout).to.equal(7000);
 			expect(mockCmd.kill.notCalled).to.be.true;
 			clock.restore();
 		});

--- a/test/unit/command/ping-command.test.ts
+++ b/test/unit/command/ping-command.test.ts
@@ -17,7 +17,7 @@ describe('ping command executor', () => {
 				type: 'ping' as PingOptions['type'],
 				timeout: 5,
 				target: 'google.com',
-				packets: 1,
+				packets: 3,
 				protocol: 'ICMP',
 				port: 80,
 				inProgressUpdates: false,
@@ -32,17 +32,17 @@ describe('ping command executor', () => {
 			expect(args[args.length - 1]).to.equal(options.target);
 			expect(joinedArgs).to.contain(`-c ${options.packets}`);
 			expect(joinedArgs).to.contain('-i 0.5');
-			expect(joinedArgs).to.contain('-w 5');
+			expect(joinedArgs).to.contain('-W 3');
 		});
 
-		it('should fit sixteen packets into a five-second deadline', () => {
+		it('should fit sixteen packets and the response wait into four seconds', () => {
 			const args = argBuilder({ type: 'ping', timeout: 5, target: 'google.com', packets: 16, protocol: 'ICMP', port: 80, inProgressUpdates: false, ipVersion: 4 });
-			expect(args.join(' ')).to.contain('-i 0.2 -w 5');
+			expect(args.join(' ')).to.contain('-i 0.2 -W 1');
 		});
 
-		it('should keep the configured interval for an eleven-second deadline', () => {
+		it('should keep the configured interval and a fractional response wait', () => {
 			const args = argBuilder({ type: 'ping', timeout: 11, target: 'google.com', packets: 16, protocol: 'ICMP', port: 80, inProgressUpdates: false, ipVersion: 4 });
-			expect(args.join(' ')).to.contain('-i 0.5 -w 11');
+			expect(args.join(' ')).to.contain('-i 0.5 -W 2.5');
 		});
 
 		it('should allow overriding ping interval', () => {

--- a/test/unit/helper/timeout.test.ts
+++ b/test/unit/helper/timeout.test.ts
@@ -24,6 +24,6 @@ describe('command timeout helpers', () => {
 	});
 
 	it('should use the configured process grace by default', () => {
-		expect(getProcessTimeout(5)).to.equal(6000);
+		expect(getProcessTimeout(5)).to.equal(7000);
 	});
 });


### PR DESCRIPTION
Increase the process grace time, and switch from `-w` to `-W` to use exactly `-c` packets.