### PR TITLE
fix: reserve DNS time in measurement commands

### DIFF
--- a/src/command/mtr-command.ts
+++ b/src/command/mtr-command.ts
@@ -12,7 +12,7 @@ import { ProgressBuffer } from '../helper/progress-buffer.js';
 import { getFailureSource, InternalError, isExposed } from '../lib/internal-error.js';
 import { scopedLogger } from '../lib/logger.js';
 import { InvalidOptionsException } from './exception/invalid-options-exception.js';
-import { getProcessTimeout } from '../helper/timeout.js';
+import { getMtrBudget, getProcessTimeout } from '../helper/timeout.js';
 import { validateCommandOptions } from '../helper/validate-command-options.js';
 
 import type {
@@ -59,9 +59,7 @@ const mtrOptionsSchema = Joi.object<MtrOptions>({
 export const getResultInitState = (): ResultType => ({ status: 'finished', hops: [], rawOutput: '', data: [] });
 
 export const argBuilder = (options: MtrOptions): string[] => {
-	const interval = options.packets * mtrConfig.interval > options.timeout - 1 ? mtrConfig.minInterval : mtrConfig.interval;
-	const remaining = Math.floor(options.timeout - options.packets * interval);
-	const grace = Math.min(3, remaining);
+	const { interval, grace, nativeTimeout } = getMtrBudget(options.packets, options.timeout);
 	const intervalArg = [ '--interval', String(interval) ];
 	const protocolArg = options.protocol === 'icmp' ? [] : `--${options.protocol}`;
 	const packetsArg = String(options.packets);
@@ -72,7 +70,7 @@ export const argBuilder = (options: MtrOptions): string[] => {
 		intervalArg,
 		[ '--gracetime', String(grace) ],
 		[ '--max-ttl', '30' ],
-		[ '--timeout', String(remaining) ],
+		[ '--timeout', String(nativeTimeout) ],
 		protocolArg,
 		[ '-c', packetsArg ],
 		[ '--raw' ],
@@ -130,7 +128,7 @@ export class MtrCommand implements CommandInterface<MtrOptions> {
 
 			const remaining = deadline - Date.now();
 
-			if (remaining <= 0) {
+			if (remaining < minimumRuntime) {
 				throw deadlineTimeoutError();
 			}
 

--- a/src/command/ping-command.ts
+++ b/src/command/ping-command.ts
@@ -1,4 +1,3 @@
-import config from 'config';
 import Joi from 'joi';
 import type { Socket } from 'socket.io-client';
 import { execa, type ExecaChildProcess } from 'execa';
@@ -11,7 +10,7 @@ import { byLine } from '../lib/by-line.js';
 import { InvalidOptionsException } from './exception/invalid-options-exception.js';
 import parse, { type PingParseOutput } from './handlers/ping/parse.js';
 import { tcpPing, formatTcpPingResult, TcpPingData } from './handlers/ping/tcp-ping.js';
-import { getLastPacketTime, getPacketInterval, getProcessTimeout } from '../helper/timeout.js';
+import { getPingBudget, getProcessTimeout } from '../helper/timeout.js';
 import { validateCommandOptions } from '../helper/validate-command-options.js';
 
 export type PingOptions = {
@@ -87,9 +86,8 @@ const classifyIcmpFailure = (error: unknown, rawOutput: string): FailureSource =
 };
 
 export const argBuilder = (options: PingOptions, commandOptions: PingCommandOptions = {}): string[] => {
-	const interval = commandOptions.interval ?? config.get<number>('commands.ping.interval');
-	const packetInterval = getPacketInterval(options.packets, options.timeout, interval, config.get<number>('commands.ping.minInterval'));
-	const responseTimeout = options.timeout - 1 - getLastPacketTime(options.packets, packetInterval);
+	const { interval: packetInterval, responseTimeout } = getPingBudget(options.packets, options.timeout, commandOptions.interval);
+
 	const args = [
 		`-${options.ipVersion}`,
 		'-O',
@@ -206,7 +204,7 @@ export class PingCommand implements CommandInterface<PingOptions> {
 			});
 		} : undefined;
 
-		const interval = getPacketInterval(cmdOptions.packets, cmdOptions.timeout, config.get<number>('commands.ping.interval'), config.get<number>('commands.ping.minInterval'));
+		const { interval } = getPingBudget(cmdOptions.packets, cmdOptions.timeout);
 		const tcpPingResult = await cmdFn({ ...cmdOptions, timeout: cmdOptions.timeout * 1000, interval: interval * 1000 }, progressHandler);
 		const result = formatTcpPingResult(tcpPingResult);
 

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -8,7 +8,7 @@ import { ipEquals, joiValidateIp, isIpPrivate } from '../lib/ip.js';
 import { scopedLogger } from '../lib/logger.js';
 import { byLine } from '../lib/by-line.js';
 import { InvalidOptionsException } from './exception/invalid-options-exception.js';
-import { getProcessTimeout } from '../helper/timeout.js';
+import { getProcessTimeout, getTracerouteBudget } from '../helper/timeout.js';
 import { validateCommandOptions } from '../helper/validate-command-options.js';
 
 const reHost = /(\S+?)(%\w+)?(\s+)\(((?:\d+\.){3}\d+|[\da-fA-F:]+)(%\w+)?\)/;
@@ -92,17 +92,19 @@ const traceOptionsSchema = Joi.object<TraceOptions>({
 });
 
 export const argBuilder = (options: TraceOptions): string[] => {
+	const packets = 2;
 	const port = options.protocol === 'TCP' ? [ '-p', `${options.port}` ] : [];
+	const { wait } = getTracerouteBudget(options.timeout, packets);
 
 	const args = [
 		// Ipv4 or IPv6
 		`-${options.ipVersion}`,
 		// Max ttl
 		[ '-m', '20' ],
-		// MAX timeout; note that this also disables the HERE and NEAR limits
-		[ '-w', String(Math.floor(options.timeout / 2)) ],
+		// Reserve 40% for DNS and overhead; the packets share the rest.
+		[ '-w', String(wait) ],
 		// Probe packets per hop
-		[ '-q', '2' ],
+		[ '-q', String(packets) ],
 		// Concurrent packets
 		[ '-N', '20' ],
 		// Protocol

--- a/src/helper/timeout.ts
+++ b/src/helper/timeout.ts
@@ -32,11 +32,9 @@ export const getPingBudget = (packets: number, timeout: number, intervalOverride
 	const preferredDnsHeadroomFloor = 2;
 	const preferredResponseTimeout = 3;
 	const maximumResponseTimeout = 5;
-	const maximumInterval = intervalOverride ?? pingConfig.interval;
+	const targetInterval = intervalOverride ?? pingConfig.interval;
 	const packetGaps = packets - 1;
-	const canPreserveInterval = intervalOverride !== undefined
-		&& packetGaps * intervalOverride + minimumDnsHeadroom + minimumResponseTimeout <= timeout;
-	let interval = canPreserveInterval || packetGaps === 0 ? maximumInterval : pingConfig.minInterval;
+	let interval = intervalOverride ?? (packetGaps === 0 ? targetInterval : pingConfig.minInterval);
 	let remaining = timeout - packetGaps * interval;
 
 	const take = (requested: number): number => {
@@ -51,7 +49,7 @@ export const getPingBudget = (packets: number, timeout: number, intervalOverride
 	dnsHeadroom += take(preferredDnsHeadroom - dnsHeadroom);
 	responseTimeout += take(preferredResponseTimeout - responseTimeout);
 
-	const intervalUpgrade = canPreserveInterval ? 0 : maximumInterval - interval;
+	const intervalUpgrade = intervalOverride === undefined ? targetInterval - interval : 0;
 	const intervalUpgradeCost = packetGaps * intervalUpgrade;
 	const responseUpgrade = maximumResponseTimeout - responseTimeout;
 	const combinedUpgradeCost = intervalUpgradeCost + responseUpgrade;

--- a/src/helper/timeout.ts
+++ b/src/helper/timeout.ts
@@ -25,15 +25,18 @@ const roundDown = (value: number, places = 2): number => {
 	return Math.floor((value + 1e-9) * scale) / scale;
 };
 
-export const getPingBudget = (packets: number, timeout: number, maxInterval = pingConfig.interval): PingBudget => {
+export const getPingBudget = (packets: number, timeout: number, intervalOverride?: number): PingBudget => {
 	const minimumDnsHeadroom = 1;
 	const minimumResponseTimeout = 1;
 	const dnsHeadroomShare = 0.2;
 	const preferredDnsHeadroomFloor = 2;
 	const preferredResponseTimeout = 3;
 	const maximumResponseTimeout = 5;
+	const maximumInterval = intervalOverride ?? pingConfig.interval;
 	const packetGaps = packets - 1;
-	let interval = packetGaps === 0 ? maxInterval : pingConfig.minInterval;
+	const canPreserveInterval = intervalOverride !== undefined
+		&& packetGaps * intervalOverride + minimumDnsHeadroom + minimumResponseTimeout <= timeout;
+	let interval = canPreserveInterval || packetGaps === 0 ? maximumInterval : pingConfig.minInterval;
 	let remaining = timeout - packetGaps * interval;
 
 	const take = (requested: number): number => {
@@ -48,12 +51,13 @@ export const getPingBudget = (packets: number, timeout: number, maxInterval = pi
 	dnsHeadroom += take(preferredDnsHeadroom - dnsHeadroom);
 	responseTimeout += take(preferredResponseTimeout - responseTimeout);
 
-	const intervalUpgradeCost = packetGaps * (maxInterval - interval);
+	const intervalUpgrade = canPreserveInterval ? 0 : maximumInterval - interval;
+	const intervalUpgradeCost = packetGaps * intervalUpgrade;
 	const responseUpgrade = maximumResponseTimeout - responseTimeout;
 	const combinedUpgradeCost = intervalUpgradeCost + responseUpgrade;
 	const progress = combinedUpgradeCost === 0 ? 0 : Math.min(1, remaining / combinedUpgradeCost);
 
-	interval += (maxInterval - interval) * progress;
+	interval += intervalUpgrade * progress;
 	responseTimeout += responseUpgrade * progress;
 	remaining -= combinedUpgradeCost * progress;
 	dnsHeadroom += remaining;

--- a/src/helper/timeout.ts
+++ b/src/helper/timeout.ts
@@ -1,13 +1,88 @@
 import config from 'config';
 
 const processGrace = config.get<number>('commands.processGrace');
+const pingConfig = config.get<{ interval: number; minInterval: number }>('commands.ping');
+const mtrConfig = config.get<{ interval: number; minInterval: number }>('commands.mtr');
 
-export const getLastPacketTime = (packets: number, interval: number): number => {
-	return (packets - 1) * interval;
+type PingBudget = {
+	interval: number;
+	responseTimeout: number;
+	dnsHeadroom: number;
 };
 
-export const getPacketInterval = (packets: number, timeout: number, interval: number, minInterval: number): number => {
-	return (packets - 1) * interval > timeout - 1 ? minInterval : interval;
+type TracerouteBudget = {
+	wait: number;
+};
+
+type MtrBudget = {
+	interval: number;
+	grace: number;
+	nativeTimeout: number;
+};
+
+const roundDown = (value: number, places = 2): number => {
+	const scale = 10 ** places;
+	return Math.floor((value + 1e-9) * scale) / scale;
+};
+
+export const getPingBudget = (packets: number, timeout: number, maxInterval = pingConfig.interval): PingBudget => {
+	const minimumDnsHeadroom = 1;
+	const minimumResponseTimeout = 1;
+	const dnsHeadroomShare = 0.2;
+	const preferredDnsHeadroomFloor = 2;
+	const preferredResponseTimeout = 3;
+	const maximumResponseTimeout = 5;
+	const packetGaps = packets - 1;
+	let interval = packetGaps === 0 ? maxInterval : pingConfig.minInterval;
+	let remaining = timeout - packetGaps * interval;
+
+	const take = (requested: number): number => {
+		const allocated = Math.max(0, Math.min(requested, remaining));
+		remaining -= allocated;
+		return allocated;
+	};
+
+	let dnsHeadroom = take(minimumDnsHeadroom);
+	let responseTimeout = take(minimumResponseTimeout);
+	const preferredDnsHeadroom = Math.max(preferredDnsHeadroomFloor, timeout * dnsHeadroomShare);
+	dnsHeadroom += take(preferredDnsHeadroom - dnsHeadroom);
+	responseTimeout += take(preferredResponseTimeout - responseTimeout);
+
+	const intervalUpgradeCost = packetGaps * (maxInterval - interval);
+	const responseUpgrade = maximumResponseTimeout - responseTimeout;
+	const combinedUpgradeCost = intervalUpgradeCost + responseUpgrade;
+	const progress = combinedUpgradeCost === 0 ? 0 : Math.min(1, remaining / combinedUpgradeCost);
+
+	interval += (maxInterval - interval) * progress;
+	responseTimeout += responseUpgrade * progress;
+	remaining -= combinedUpgradeCost * progress;
+	dnsHeadroom += remaining;
+
+	return {
+		interval: roundDown(interval),
+		responseTimeout: roundDown(responseTimeout),
+		dnsHeadroom: roundDown(dnsHeadroom),
+	};
+};
+
+export const getTracerouteBudget = (timeout: number, packets: number): TracerouteBudget => {
+	const maximumWait = 5;
+	const probeTimeoutShare = 0.6;
+	const wait = Math.min(maximumWait, roundDown(timeout * probeTimeoutShare / packets));
+
+	return { wait };
+};
+
+export const getMtrBudget = (packets: number, remaining: number): MtrBudget => {
+	const minimumGrace = 1;
+	const maximumGrace = 3;
+	const minimumNativeTimeout = 1;
+	const grace = Math.min(maximumGrace, Math.max(minimumGrace, Math.floor(remaining - packets * mtrConfig.minInterval)));
+	const calculatedInterval = Math.min(mtrConfig.interval, Math.max(mtrConfig.minInterval, (remaining - grace) / packets));
+	const interval = roundDown(calculatedInterval);
+	const nativeTimeout = Math.max(minimumNativeTimeout, Math.floor(remaining - packets * interval));
+
+	return { interval, grace, nativeTimeout };
 };
 
 export const getProcessTimeout = (timeout: number, grace = processGrace): number => {

--- a/test/unit/command/mtr-command.test.ts
+++ b/test/unit/command/mtr-command.test.ts
@@ -53,9 +53,11 @@ describe('mtr command executor', () => {
 		});
 
 		for (const { packets, timeout, interval, grace, remaining } of [
-			{ packets: 5, timeout: 5, interval: 0.5, grace: 2, remaining: 2 },
-			{ packets: 16, timeout: 5, interval: 0.2, grace: 1, remaining: 1 },
+			{ packets: 5, timeout: 5, interval: 0.4, grace: 3, remaining: 3 },
+			{ packets: 16, timeout: 5, interval: 0.25, grace: 1, remaining: 1 },
 			{ packets: 16, timeout: 11, interval: 0.5, grace: 3, remaining: 3 },
+			{ packets: 16, timeout: 6.8, interval: 0.23, grace: 3, remaining: 3 },
+			{ packets: 16, timeout: 4.2, interval: 0.2, grace: 1, remaining: 1 },
 		]) {
 			it(`should fit ${packets} packets into a ${timeout} second budget`, () => {
 				const args = argBuilder({
@@ -75,7 +77,7 @@ describe('mtr command executor', () => {
 			});
 		}
 
-		it('should keep the remaining budget at one second or more for supported options', () => {
+		it('should keep native arguments within every supported budget', () => {
 			for (let timeout = 5; timeout <= 30; timeout++) {
 				for (let packets = 1; packets <= 16; packets++) {
 					const args = argBuilder({
@@ -88,10 +90,15 @@ describe('mtr command executor', () => {
 						inProgressUpdates: false,
 						ipVersion: 4,
 					});
+					const interval = Number(args[args.indexOf('--interval') + 1]);
+					const grace = Number(args[args.indexOf('--gracetime') + 1]);
 					const remaining = Number(args[args.indexOf('--timeout') + 1]);
 
+					expect(interval).to.be.within(0.2, 0.5);
+					expect(grace).to.be.oneOf([ 1, 2, 3 ]);
 					expect(remaining).to.be.at.least(1);
 					expect(Number.isInteger(remaining)).to.equal(true);
+					expect(packets * interval + grace).to.be.at.most(timeout + 1e-9);
 				}
 			}
 		});
@@ -304,11 +311,44 @@ describe('mtr command executor', () => {
 
 			await clock.tickAsync(2900);
 
-			expect(passedArgs[passedArgs.indexOf('--interval') + 1]).to.equal('0.2');
+			expect(passedArgs[passedArgs.indexOf('--interval') + 1]).to.equal('0.36');
 			expect(passedProcessTimeout).to.equal(4100);
 
 			mockCmd.resolve({ stdout: '' });
 			await runPromise;
+			clock.restore();
+		});
+
+		it('should not start MTR when successful target lookup leaves less than the minimum runtime', async () => {
+			const clock = sandbox.useFakeTimers();
+			const timeoutStub = sandbox.stub(AbortSignal, 'timeout').returns(new AbortController().signal);
+			const mockCmd = getExecaMock();
+			const cmdFn = sandbox.spy((): any => mockCmd);
+			const lookup = (async (_hostname: string, options: any) => {
+				if (options.rrtype) {
+					return [ '123 | abc | abc' ];
+				}
+
+				return new Promise(resolve => setTimeout(() => resolve([ '1.1.1.1', options.family ]), 2700));
+			}) as typeof cachedDnsLookup;
+			const mtr = new MtrCommand(cmdFn, lookup);
+			const runPromise = mtr.run(mockedSocket as any, 'measurement', 'test', {
+				type: 'mtr', timeout: 5, target: 'jsdelivr.net', protocol: 'icmp', port: 80, packets: 7, inProgressUpdates: false, ipVersion: 4,
+			});
+			mockCmd.resolve({ stdout: '' });
+
+			await clock.tickAsync(2700);
+			await runPromise;
+
+			expect(cmdFn.notCalled).to.be.true;
+
+			expect((mockedSocket.emit.firstCall.args[1] as any).result).to.include({
+				status: 'failed',
+				failureSource: 'target',
+				rawOutput: 'The measurement command timed out.',
+			});
+
+			timeoutStub.restore();
 			clock.restore();
 		});
 

--- a/test/unit/command/ping-command.test.ts
+++ b/test/unit/command/ping-command.test.ts
@@ -31,8 +31,13 @@ describe('ping command executor', () => {
 			expect(args[1]).to.equal('-O');
 			expect(args[args.length - 1]).to.equal(options.target);
 			expect(joinedArgs).to.contain(`-c ${options.packets}`);
-			expect(joinedArgs).to.contain('-i 0.5');
-			expect(joinedArgs).to.contain('-W 3');
+			expect(joinedArgs).to.contain('-i 0.2');
+			expect(joinedArgs).to.contain('-W 2.6');
+		});
+
+		it('should use full interval and response wait with the default timeout', () => {
+			const args = argBuilder({ type: 'ping', timeout: 10, target: 'google.com', packets: 3, protocol: 'ICMP', port: 80, inProgressUpdates: false, ipVersion: 4 });
+			expect(args.join(' ')).to.contain('-i 0.5 -W 5');
 		});
 
 		it('should fit sixteen packets and the response wait into four seconds', () => {
@@ -40,9 +45,9 @@ describe('ping command executor', () => {
 			expect(args.join(' ')).to.contain('-i 0.2 -W 1');
 		});
 
-		it('should keep the configured interval and a fractional response wait', () => {
-			const args = argBuilder({ type: 'ping', timeout: 11, target: 'google.com', packets: 16, protocol: 'ICMP', port: 80, inProgressUpdates: false, ipVersion: 4 });
-			expect(args.join(' ')).to.contain('-i 0.5 -W 2.5');
+		it('should increase interval and response wait gradually', () => {
+			const args = argBuilder({ type: 'ping', timeout: 10, target: 'google.com', packets: 16, protocol: 'ICMP', port: 80, inProgressUpdates: false, ipVersion: 4 });
+			expect(args.join(' ')).to.contain('-i 0.29 -W 3.61');
 		});
 
 		it('should allow overriding ping interval', () => {
@@ -280,6 +285,25 @@ describe('ping command executor', () => {
 				expect(mockedSocket.emit.lastCall.args).to.deep.equal([ 'probe:measurement:result', expectedResult ]);
 			});
 		}
+
+		it('should use the dynamic packet interval for TCP ping', async () => {
+			const options = {
+				type: 'ping' as PingOptions['type'],
+				timeout: 10,
+				target: 'google.com',
+				packets: 16,
+				protocol: 'TCP',
+				port: 80,
+				inProgressUpdates: false,
+				ipVersion: 4 as const,
+			};
+			const tcpHandler = sandbox.stub().resolves([]);
+			const ping = new PingCommand();
+
+			await ping.runTcp(tcpHandler, mockedSocket as any, 'measurement', 'test', options);
+
+			expect(tcpHandler.firstCall.args[0]).to.deep.include({ timeout: 10_000, interval: 290 });
+		});
 
 		for (const command of tcpCommands) {
 			it(`should run and parse successful commands without progress updates - ${command}`, async () => {

--- a/test/unit/command/ping-command.test.ts
+++ b/test/unit/command/ping-command.test.ts
@@ -50,12 +50,12 @@ describe('ping command executor', () => {
 			expect(args.join(' ')).to.contain('-i 0.29 -W 3.61');
 		});
 
-		it('should allow overriding ping interval', () => {
+		it('should preserve the status-check ping interval', () => {
 			const options = {
 				type: 'ping' as PingOptions['type'],
-				timeout: 5,
-				target: 'google.com',
-				packets: 1,
+				timeout: 10,
+				target: 'api.globalping.io',
+				packets: 6,
 				protocol: 'ICMP',
 				port: 80,
 				inProgressUpdates: false,
@@ -64,7 +64,7 @@ describe('ping command executor', () => {
 
 			const args = argBuilder(options, { interval: 1 });
 
-			expect(args.join(' ')).to.contain('-i 1');
+			expect(args.join(' ')).to.contain('-i 1 -W 3');
 		});
 
 		describe('ipVersion', () => {

--- a/test/unit/command/traceroute-command.test.ts
+++ b/test/unit/command/traceroute-command.test.ts
@@ -29,25 +29,32 @@ describe('trace command', () => {
 			expect(args[args.length - 1]).to.equal(options.target);
 			expect(joinedArgs).to.contain('-m 20');
 			expect(joinedArgs).to.contain('-N 20');
-			expect(joinedArgs).to.contain('-w 2');
+			expect(joinedArgs).to.contain('-w 1.5');
 			expect(joinedArgs).to.contain('-q 2');
 			expect(joinedArgs).to.contain(`--${options.protocol.toLowerCase()}`);
 			expect(joinedArgs).to.contain(`-p ${options.port}`);
 		});
 
-		it('should derive the native wait from the measurement timeout', () => {
-			const args = argBuilder({
-				type: 'traceroute',
-				timeout: 11,
-				target: 'google.com',
-				port: 80,
-				protocol: 'TCP',
-				inProgressUpdates: false,
-				ipVersion: 4,
-			});
+		for (const { timeout, wait } of [
+			{ timeout: 10, wait: 3 },
+			{ timeout: 16, wait: 4.8 },
+			{ timeout: 17, wait: 5 },
+			{ timeout: 30, wait: 5 },
+		]) {
+			it(`should derive a ${wait} second native wait from a ${timeout} second timeout`, () => {
+				const args = argBuilder({
+					type: 'traceroute',
+					timeout,
+					target: 'google.com',
+					port: 80,
+					protocol: 'TCP',
+					inProgressUpdates: false,
+					ipVersion: 4,
+				});
 
-			expect(args.join(' ')).to.contain('-w 5');
-		});
+				expect(args.join(' ')).to.contain(`-w ${wait}`);
+			});
+		}
 
 		describe('ipVersion', () => {
 			it('should set -4 flag', () => {

--- a/test/unit/helper/timeout.test.ts
+++ b/test/unit/helper/timeout.test.ts
@@ -1,22 +1,94 @@
 import { expect } from 'chai';
 import {
-	getLastPacketTime,
-	getPacketInterval,
+	getMtrBudget,
+	getPingBudget,
 	getProcessTimeout,
+	getTracerouteBudget,
 } from '../../../src/helper/timeout.js';
 
 describe('command timeout helpers', () => {
-	it('should keep the configured packet interval when it fits the timeout', () => {
-		expect(getPacketInterval(3, 5, 0.5, 0.25)).to.equal(0.5);
-		expect(getPacketInterval(16, 11, 0.5, 0.25)).to.equal(0.5);
+	describe('ping budget', () => {
+		for (const { packets, timeout, expected } of [
+			{ packets: 3, timeout: 5, expected: { interval: 0.2, responseTimeout: 2.6, dnsHeadroom: 2 } },
+			{ packets: 3, timeout: 6, expected: { interval: 0.26, responseTimeout: 3.46, dnsHeadroom: 2 } },
+			{ packets: 3, timeout: 8, expected: { interval: 0.5, responseTimeout: 5, dnsHeadroom: 2 } },
+			{ packets: 3, timeout: 10, expected: { interval: 0.5, responseTimeout: 5, dnsHeadroom: 4 } },
+			{ packets: 16, timeout: 5, expected: { interval: 0.2, responseTimeout: 1, dnsHeadroom: 1 } },
+			{ packets: 16, timeout: 10, expected: { interval: 0.29, responseTimeout: 3.61, dnsHeadroom: 2 } },
+			{ packets: 16, timeout: 16, expected: { interval: 0.5, responseTimeout: 5, dnsHeadroom: 3.5 } },
+		]) {
+			it(`should allocate ${packets} packets within ${timeout} seconds`, () => {
+				expect(getPingBudget(packets, timeout)).to.deep.equal(expected);
+			});
+		}
+
+		it('should keep every supported packet and timeout combination within budget', () => {
+			for (let timeout = 5; timeout <= 30; timeout++) {
+				for (let packets = 1; packets <= 16; packets++) {
+					const { interval, responseTimeout, dnsHeadroom } = getPingBudget(packets, timeout);
+
+					expect(interval).to.be.within(0.2, 0.5);
+					expect(responseTimeout).to.be.within(1, 5);
+					expect(dnsHeadroom).to.be.at.least(1);
+					expect((packets - 1) * interval + responseTimeout + dnsHeadroom).to.be.at.most(timeout);
+				}
+			}
+		});
 	});
 
-	it('should shorten the packet interval when it exceeds the timeout', () => {
-		expect(getPacketInterval(16, 5, 0.5, 0.2)).to.equal(0.2);
+	describe('traceroute budget', () => {
+		for (const { timeout, probeWaves, expected } of [
+			{ timeout: 5, probeWaves: 2, expected: { wait: 1.5 } },
+			{ timeout: 5, probeWaves: 4, expected: { wait: 0.75 } },
+			{ timeout: 10, probeWaves: 2, expected: { wait: 3 } },
+			{ timeout: 10, probeWaves: 3, expected: { wait: 2 } },
+			{ timeout: 16, probeWaves: 2, expected: { wait: 4.8 } },
+			{ timeout: 17, probeWaves: 2, expected: { wait: 5 } },
+			{ timeout: 30, probeWaves: 2, expected: { wait: 5 } },
+		]) {
+			it(`should allocate ${probeWaves} probe waves within ${timeout} seconds`, () => {
+				expect(getTracerouteBudget(timeout, probeWaves)).to.deep.equal(expected);
+			});
+		}
+
+		it('should keep two probe waves within the supported timeout range', () => {
+			for (let timeout = 5; timeout <= 30; timeout++) {
+				const { wait } = getTracerouteBudget(timeout, 2);
+
+				expect(wait).to.be.at.most(5);
+				expect(2 * wait).to.be.at.most(10);
+				expect(2 * wait).to.be.at.most(timeout * 0.6 + 1e-9);
+			}
+		});
 	});
 
-	it('should calculate the time of the last packet', () => {
-		expect(getLastPacketTime(16, 0.25)).to.equal(3.75);
+	describe('mtr budget', () => {
+		for (const { packets, remaining, expected } of [
+			{ packets: 3, remaining: 4.5, expected: { interval: 0.5, grace: 3, nativeTimeout: 3 } },
+			{ packets: 16, remaining: 11, expected: { interval: 0.5, grace: 3, nativeTimeout: 3 } },
+			{ packets: 16, remaining: 6.8, expected: { interval: 0.23, grace: 3, nativeTimeout: 3 } },
+			{ packets: 16, remaining: 4.2, expected: { interval: 0.2, grace: 1, nativeTimeout: 1 } },
+		]) {
+			it(`should allocate ${packets} packets within ${remaining} seconds`, () => {
+				expect(getMtrBudget(packets, remaining)).to.deep.equal(expected);
+			});
+		}
+
+		it('should keep viable fractional budgets within native limits', () => {
+			for (let packets = 1; packets <= 16; packets++) {
+				const minimumRuntime = packets * 0.2 + 1;
+
+				for (const remaining of [ minimumRuntime, minimumRuntime + 0.37, minimumRuntime + 2.91, 30 ]) {
+					const { interval, grace, nativeTimeout } = getMtrBudget(packets, remaining);
+
+					expect(interval).to.be.within(0.2, 0.5);
+					expect(grace).to.be.oneOf([ 1, 2, 3 ]);
+					expect(Number.isInteger(nativeTimeout)).to.equal(true);
+					expect(nativeTimeout).to.be.at.least(1);
+					expect(packets * interval + grace).to.be.at.most(remaining + 1e-9);
+				}
+			}
+		});
 	});
 
 	it('should allow two extra seconds for the process timeout', () => {

--- a/test/unit/helper/timeout.test.ts
+++ b/test/unit/helper/timeout.test.ts
@@ -35,12 +35,8 @@ describe('command timeout helpers', () => {
 			}
 		});
 
-		it('should preserve an explicit interval when the minimum DNS and response budgets still fit', () => {
+		it('should preserve an explicit interval', () => {
 			expect(getPingBudget(6, 10, 1)).to.deep.equal({ interval: 1, responseTimeout: 3, dnsHeadroom: 2 });
-		});
-
-		it('should fall back to dynamic allocation when an explicit interval does not fit', () => {
-			expect(getPingBudget(16, 5, 1)).to.deep.equal({ interval: 0.2, responseTimeout: 1, dnsHeadroom: 1 });
 		});
 	});
 

--- a/test/unit/helper/timeout.test.ts
+++ b/test/unit/helper/timeout.test.ts
@@ -34,6 +34,14 @@ describe('command timeout helpers', () => {
 				}
 			}
 		});
+
+		it('should preserve an explicit interval when the minimum DNS and response budgets still fit', () => {
+			expect(getPingBudget(6, 10, 1)).to.deep.equal({ interval: 1, responseTimeout: 3, dnsHeadroom: 2 });
+		});
+
+		it('should fall back to dynamic allocation when an explicit interval does not fit', () => {
+			expect(getPingBudget(16, 5, 1)).to.deep.equal({ interval: 0.2, responseTimeout: 1, dnsHeadroom: 1 });
+		});
 	});
 
 	describe('traceroute budget', () => {


### PR DESCRIPTION
Reserve meaningful DNS headroom within ping and traceroute deadlines, and dynamically allocate ping, traceroute, and MTR command timing so measurements degrade predictably across supported packet and timeout combinations.