### PR TITLE
perf: increase DNS cache retention

### DIFF
--- a/src/lib/dns.ts
+++ b/src/lib/dns.ts
@@ -12,11 +12,13 @@ type Options = LookupOptions | RecordOptions;
 
 type ResolvedRecords = { records: string[]; ttl: number };
 
-const DNS_CACHE_MAX_TTL = 5 * 60 * 1000;
+const DNS_CACHE_MIN_TTL = 60 * 1000;
+const DNS_CACHE_TXT_TTL = 5 * 60 * 1000;
+const DNS_CACHE_MAX_ENTRIES = 5000;
 
 const cache = new TTLCache<string, Promise<string[]>>({
-	max: 1000,
-	ttl: DNS_CACHE_MAX_TTL,
+	max: DNS_CACHE_MAX_ENTRIES,
+	ttl: DNS_CACHE_TXT_TTL,
 });
 
 export const clearDnsCache = () => cache.clear();
@@ -49,20 +51,19 @@ const resolveRecords = async (hostname: string, options: Options): Promise<Resol
 			if ('rrtype' in options) {
 				// Only TXT records are supported as other RRtypes have different TS return types.
 				const records = (await resolver.resolveTxt(hostname)).map(record => record.join(''));
-				// TXT records carry no TTL here, so they fall back to the max cache TTL.
-				return { records, ttl: DNS_CACHE_MAX_TTL };
+				// TXT records carry no TTL here, so they use a fixed cache TTL.
+				return { records, ttl: DNS_CACHE_TXT_TTL };
 			}
 
 			const records = options.family === 6
 				? await resolver.resolve6(hostname, { ttl: true })
 				: await resolver.resolve4(hostname, { ttl: true });
 
-			let ttl = DNS_CACHE_MAX_TTL;
+			let ttl = DNS_CACHE_MIN_TTL;
 
 			if (records.length) {
-				const minResolvedTtl = Math.min(DNS_CACHE_MAX_TTL, Math.min(...records.map(record => record.ttl)) * 1000);
-				// TTL: 0 is invalid, so we set it to 1.
-				ttl = Math.max(1, minResolvedTtl);
+				const minResolvedTtl = Math.min(...records.map(record => record.ttl)) * 1000;
+				ttl = Math.max(DNS_CACHE_MIN_TTL, minResolvedTtl);
 			}
 
 			return { records: records.map(record => record.address), ttl };

--- a/test/unit/lib/dns.test.ts
+++ b/test/unit/lib/dns.test.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import dns from 'node:dns';
+import { performance } from 'node:perf_hooks';
 import { getDnsServers, dnsLookup, cachedDnsLookup, clearDnsCache } from '../../../src/lib/dns.js';
 import { getFailureSource } from '../../../src/lib/internal-error.js';
 import { callbackify } from '../../../src/lib/util.js';
@@ -118,7 +119,10 @@ describe('dnsLookup / cachedDnsLookup', () => {
 		resolve4 = sandbox.stub(dns.promises.Resolver.prototype, 'resolve4').resolves([{ address: '1.1.1.1', ttl: 300 }]);
 	});
 
-	afterEach(() => sandbox.restore());
+	afterEach(() => {
+		clearDnsCache();
+		sandbox.restore();
+	});
 
 	it('returns the first public address with its family', async () => {
 		expect(await dnsLookup('example.com', { family: 4 })).to.deep.equal([ '1.1.1.1', 4 ]);
@@ -256,14 +260,52 @@ describe('dnsLookup / cachedDnsLookup', () => {
 		expect(resolve4.callCount).to.equal(3);
 	});
 
-	it('expires the cache entry once the record ttl elapses', async () => {
+	it('caches records for at least one minute', async () => {
+		let now = 0;
+		sandbox.stub(performance, 'now').callsFake(() => now);
+		const clock = sandbox.useFakeTimers({ toFake: [ 'setTimeout', 'clearTimeout' ] });
 		resolve4.resolves([{ address: '1.1.1.1', ttl: 0 }]);
 
 		await cachedDnsLookup('example.com', { family: 4 });
-		await new Promise(resolve => setTimeout(resolve, 10));
+		now = 59_999;
+		await clock.tickAsync(59_999);
+		await cachedDnsLookup('example.com', { family: 4 });
+
+		expect(resolve4.callCount).to.equal(1);
+
+		now = 60_000;
+		await clock.tickAsync(1);
 		await cachedDnsLookup('example.com', { family: 4 });
 
 		expect(resolve4.callCount).to.equal(2);
+	});
+
+	it('honors authoritative ttls longer than five minutes', async () => {
+		let now = 0;
+		sandbox.stub(performance, 'now').callsFake(() => now);
+		const clock = sandbox.useFakeTimers({ toFake: [ 'setTimeout', 'clearTimeout' ] });
+		resolve4.resolves([{ address: '1.1.1.1', ttl: 600 }]);
+
+		await cachedDnsLookup('example.com', { family: 4 });
+		now = 5 * 60 * 1000 + 1;
+		await clock.tickAsync(5 * 60 * 1000 + 1);
+		await cachedDnsLookup('example.com', { family: 4 });
+
+		expect(resolve4.callCount).to.equal(1);
+	});
+
+	it('keeps at most 5000 entries', async () => {
+		resolve4.resolves([{ address: '1.1.1.1', ttl: 300 }]);
+
+		for (let i = 0; i < 5001; i++) {
+			await cachedDnsLookup(`example-${i}.com`, { family: 4 });
+		}
+
+		await cachedDnsLookup('example-1.com', { family: 4 });
+		expect(resolve4.callCount).to.equal(5001);
+
+		await cachedDnsLookup('example-0.com', { family: 4 });
+		expect(resolve4.callCount).to.equal(5002);
 	});
 
 	it('does not cache failures', async () => {

--- a/test/unit/lib/dns.test.ts
+++ b/test/unit/lib/dns.test.ts
@@ -292,6 +292,12 @@ describe('dnsLookup / cachedDnsLookup', () => {
 		await cachedDnsLookup('example.com', { family: 4 });
 
 		expect(resolve4.callCount).to.equal(1);
+
+		now = 10 * 60 * 1000;
+		await clock.tickAsync(5 * 60 * 1000 - 1);
+		await cachedDnsLookup('example.com', { family: 4 });
+
+		expect(resolve4.callCount).to.equal(2);
 	});
 
 	it('keeps at most 5000 entries', async () => {


### PR DESCRIPTION
Caches successful DNS answers for at least one minute, honors longer authoritative TTLs, and raises the cache limit to 5,000 entries.