### PR TITLE
feat: preserve partial HTTP data on timeout

### DIFF
--- a/src/command/handlers/http/undici.ts
+++ b/src/command/handlers/http/undici.ts
@@ -530,20 +530,26 @@ export class HttpHandler {
 		this.sendResult();
 	};
 
-	private handleError = (error: Error | string, fallbackSource: FailureSource, preserveTimings = false) => {
+	private handleError = (error: Error | string, fallbackSource: FailureSource, preserveCompletedState = false) => {
 		if (this.done) {
 			return;
 		}
 
 		const message = error instanceof Error ? error.message : error;
 		this.done = true;
-		Object.assign(this.result, this.getInitialResult());
+
+		if (preserveCompletedState) {
+			this.result.rawBody = '';
+		} else {
+			Object.assign(this.result, this.getInitialResult());
+		}
+
 		this.result.status = 'failed';
 		const codeFallback = isInternalHttpErrorCode(getErrorCode(error)) ? 'internal' : fallbackSource;
 		this.result.failureSource = getFailureSource(error, codeFallback);
 		this.result.rawOutput = message;
 
-		if (preserveTimings && this.timings.start !== null) {
+		if (preserveCompletedState && this.timings.start !== null) {
 			this.timings.total = Date.now() - this.timings.start;
 		} else {
 			for (const key of Object.keys(this.timings) as (keyof Timings)[]) {

--- a/src/command/handlers/http/undici.ts
+++ b/src/command/handlers/http/undici.ts
@@ -81,9 +81,18 @@ export type OutputJson = {
 };
 
 type Decompressor = zlib.Gunzip | zlib.Inflate | zlib.BrotliDecompress;
-type ConnectionState = { isResolving: boolean };
+type RequestPhase = 'dns' | 'tcp' | 'tls' | 'firstByte' | 'download';
+type RequestState = { phase: RequestPhase };
 
 const lowerCaseKeys = (obj: Record<string, string>) => _.mapKeys(obj, (_value, key) => _.toLower(key)) as Record<string, string>;
+
+const timeoutMessages: Record<RequestPhase, string> = {
+	dns: 'Request timed out during DNS lookup.',
+	tcp: 'Request timed out while establishing the TCP connection.',
+	tls: 'Request timed out during the TLS handshake.',
+	firstByte: 'Request timed out while waiting for the first response byte.',
+	download: 'Request timed out while downloading the response.',
+};
 
 const internalHttpErrorCodes = new Set([
 	'EMFILE',
@@ -154,11 +163,11 @@ function getConnector (
 	dnsResolver: LookupFunction,
 	result: Omit<Result, 'timings'>,
 	timings: Timings,
-	connectionState: ConnectionState,
+	requestState: RequestState,
 ): buildConnector.connector {
 	return (connectorOptions, callback) => {
 		timings.start = Date.now();
-		connectionState.isResolving = isIP(connectorOptions.hostname) === 0;
+		requestState.phase = isIP(connectorOptions.hostname) === 0 ? 'dns' : 'tcp';
 
 		const tcpSocket = net.connect({
 			host: connectorOptions.hostname,
@@ -169,12 +178,12 @@ function getConnector (
 		});
 
 		tcpSocket.on('lookup', (error, address) => {
-			connectionState.isResolving = false;
-
 			if (error) {
 				// Handled in onError().
 				return;
 			}
+
+			requestState.phase = 'tcp';
 
 			if (isIpPrivate(address)) {
 				tcpSocket.destroy();
@@ -202,6 +211,7 @@ function getConnector (
 			}
 
 			timings.tcp = Date.now() - timings.start! - (timings.dns ?? 0);
+			requestState.phase = isHttps ? 'tls' : 'firstByte';
 
 			if (!result.resolvedAddress && tcpSocket.remoteAddress) {
 				result.resolvedAddress = tcpSocket.remoteAddress;
@@ -240,6 +250,7 @@ function getConnector (
 
 			tlsSocket.on('secureConnect', () => {
 				timings.tls = Date.now() - timings.start! - (timings.dns ?? 0) - (timings.tcp ?? 0);
+				requestState.phase = 'firstByte';
 				const cert = tlsSocket.getPeerCertificate();
 				const alpn = tlsSocket.alpnProtocol;
 
@@ -323,12 +334,12 @@ export class HttpHandler {
 			...(server ? { server } : {}),
 		}), true);
 		const allowH2 = this.options.protocol === 'HTTP2';
-		const connectionState: ConnectionState = { isResolving: false };
-		const connector = getConnector(this.options, this.port, this.isHttps, dnsResolver, this.result, this.timings, connectionState);
+		const requestState: RequestState = { phase: isIP(this.options.target) === 0 ? 'dns' : 'tcp' };
+		const connector = getConnector(this.options, this.port, this.isHttps, dnsResolver, this.result, this.timings, requestState);
 		this.undiciClient = new Client(this.url.origin, { connect: connector, allowH2 });
 
 		this.timeoutTimer = setTimeout(
-			() => this.handleError('Request timeout.', connectionState.isResolving ? 'resolver' : 'target'),
+			() => this.handleError(timeoutMessages[requestState.phase], requestState.phase === 'dns' ? 'resolver' : 'target', true),
 			this.options.timeout * 1000,
 		);
 
@@ -349,6 +360,7 @@ export class HttpHandler {
 				this.timings.firstByte = Date.now() - this.timings.start! - (this.timings.dns ?? 0) - (this.timings.tcp ?? 0) - (this.timings.tls ?? 0);
 				this.result.statusCode = statusCode;
 				this.result.statusCodeName = statusText;
+				requestState.phase = 'download';
 
 				const rawHeaderPairs = [];
 
@@ -518,7 +530,7 @@ export class HttpHandler {
 		this.sendResult();
 	};
 
-	private handleError = (error: Error | string, fallbackSource: FailureSource) => {
+	private handleError = (error: Error | string, fallbackSource: FailureSource, preserveTimings = false) => {
 		if (this.done) {
 			return;
 		}
@@ -531,8 +543,12 @@ export class HttpHandler {
 		this.result.failureSource = getFailureSource(error, codeFallback);
 		this.result.rawOutput = message;
 
-		for (const key of Object.keys(this.timings) as (keyof Timings)[]) {
-			this.timings[key] = null;
+		if (preserveTimings && this.timings.start !== null) {
+			this.timings.total = Date.now() - this.timings.start;
+		} else {
+			for (const key of Object.keys(this.timings) as (keyof Timings)[]) {
+				this.timings[key] = null;
+			}
 		}
 
 		this.cleanup();

--- a/test/unit/command/http-command.test.ts
+++ b/test/unit/command/http-command.test.ts
@@ -306,7 +306,7 @@ describe(`.run() method`, () => {
 		return { getRequest: () => request };
 	};
 
-	const mockHttpsResponse = (response: string[], options?: { address?: string }) => {
+	const mockHttpsResponse = (response: string[], options?: { address?: string; endResponse?: boolean }) => {
 		let request = '';
 		const tcpSocket = new Duplex({
 			read () {},
@@ -365,7 +365,10 @@ describe(`.run() method`, () => {
 				tlsSocket.emit('secureConnect');
 				sandbox.clock.tick(5);
 				tlsSocket.push(response.join('\r\n'));
-				tlsSocket.push(null);
+
+				if (options?.endResponse !== false) {
+					tlsSocket.push(null);
+				}
 			});
 
 			return tlsSocket as any;
@@ -1262,6 +1265,74 @@ describe(`.run() method`, () => {
 			dns: 0,
 			tls: null,
 			tcp: 10,
+		});
+	});
+
+	it('should preserve completed response data while clearing a partial body on timeout', async () => {
+		mockHttpsResponse([
+			'HTTP/1.1 200 OK',
+			'test: abc',
+			'Content-Length: 10',
+			'',
+			'part',
+		], { endResponse: false });
+
+		const promise = new HttpCommand().run(mockedSocket as any, 'measurement', 'test', {
+			type: 'http' as const,
+			timeout: 5,
+			target: 'example.com',
+			inProgressUpdates: false,
+			protocol: 'HTTPS',
+			request: { method: 'GET', path: '/timeout', query: '' },
+			ipVersion: 4,
+		});
+
+		await new Promise(resolve => process.nextTick(resolve));
+		await new Promise(resolve => process.nextTick(resolve));
+		await new Promise(resolve => process.nextTick(resolve));
+		sandbox.clock.tick(5_001);
+
+		await promise;
+
+		const result = mockedSocket.emit.firstCall.args[1].result;
+
+		expect(result.status).to.equal('failed');
+		expect(result.failureSource).to.equal('target');
+		expect(result.resolvedAddress).to.equal('93.184.216.34');
+		expect(result.headers).to.deep.equal({ 'test': 'abc', 'content-length': '10' });
+		expect(result.rawHeaders).to.equal('test: abc\nContent-Length: 10');
+		expect(result.rawBody).to.equal(null);
+		expect(result.rawOutput).to.equal('Request timed out while downloading the response.');
+		expect(result.truncated).to.equal(false);
+		expect(result.statusCode).to.equal(200);
+		expect(result.statusCodeName).to.equal('OK');
+
+		expect(result.timings).to.deep.equal({
+			total: 5000,
+			download: null,
+			firstByte: 5,
+			dns: 0,
+			tls: 20,
+			tcp: 10,
+		});
+
+		expect(result.tls).to.deep.equal({
+			authorized: true,
+			protocol: 'TLSv1.3',
+			cipherName: 'TLS_AES_256_GCM_SHA384',
+			createdAt: '2023-12-01T00:00:00.000Z',
+			expiresAt: '2024-12-01T23:59:59.000Z',
+			issuer: {
+				C: 'US',
+				O: 'DigiCert Inc',
+				CN: 'DigiCert TLS RSA SHA256 2020 CA1',
+			},
+			subject: { CN: 'example.com', alt: 'DNS:example.com, DNS:www.example.com' },
+			keyType: 'RSA',
+			keyBits: 2048,
+			serialNumber: 'AB:C1:23',
+			fingerprint256: 'AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99:AA:BB:CC:DD:EE:FF:00:11:22:33:44:55:66:77:88:99',
+			publicKey: '30:82:01:0A:02:82:01:01:00',
 		});
 	});
 

--- a/test/unit/command/http-command.test.ts
+++ b/test/unit/command/http-command.test.ts
@@ -1053,7 +1053,16 @@ describe(`.run() method`, () => {
 
 		expect(result.status).to.equal('failed');
 		expect(result.failureSource).to.equal('resolver');
-		expect(result.rawOutput).to.equal('Request timeout.');
+		expect(result.rawOutput).to.equal('Request timed out during DNS lookup.');
+
+		expect(result.timings).to.deep.equal({
+			total: 5000,
+			download: null,
+			firstByte: null,
+			dns: null,
+			tls: null,
+			tcp: null,
+		});
 	});
 
 	it('should classify a timeout for an IP target as target', async () => {
@@ -1084,7 +1093,74 @@ describe(`.run() method`, () => {
 
 		expect(result.status).to.equal('failed');
 		expect(result.failureSource).to.equal('target');
-		expect(result.rawOutput).to.equal('Request timeout.');
+		expect(result.rawOutput).to.equal('Request timed out while establishing the TCP connection.');
+
+		expect(result.timings).to.deep.equal({
+			total: 5000,
+			download: null,
+			firstByte: null,
+			dns: null,
+			tls: null,
+			tcp: null,
+		});
+	});
+
+	it('should report a timeout during the TLS handshake and preserve completed timings', async () => {
+		const tcpSocket = new Duplex({
+			read () {},
+			write (_chunk, _encoding, callback) {
+				callback();
+			},
+		});
+		(tcpSocket as any).remoteAddress = '93.184.216.34';
+
+		netConnectStub.callsFake(() => {
+			process.nextTick(() => {
+				tcpSocket.emit('lookup', null, '93.184.216.34', 4, 'example.com');
+				sandbox.clock.tick(10);
+				tcpSocket.emit('connect');
+			});
+
+			return tcpSocket as any;
+		});
+
+		const tlsSocket = new Duplex({
+			read () {},
+			write (_chunk, _encoding, callback) {
+				callback();
+			},
+		});
+		sandbox.stub(tls, 'connect').returns(tlsSocket as any);
+
+		const promise = new HttpCommand().run(mockedSocket as any, 'measurement', 'test', {
+			type: 'http' as const,
+			timeout: 5,
+			target: 'example.com',
+			inProgressUpdates: false,
+			protocol: 'HTTPS',
+			request: { method: 'GET', path: '/timeout', query: '' },
+			ipVersion: 4,
+		});
+
+		await new Promise(resolve => process.nextTick(resolve));
+		sandbox.clock.tick(5_001);
+
+		await promise;
+
+		const result = mockedSocket.emit.firstCall.args[1].result;
+
+		expect(result.status).to.equal('failed');
+		expect(result.failureSource).to.equal('target');
+		expect(result.rawOutput).to.equal('Request timed out during the TLS handshake.');
+
+		expect(result.timings).to.deep.equal({
+			total: 5000,
+			download: null,
+			firstByte: null,
+			dns: 0,
+			tls: null,
+			tcp: 10,
+		});
 	});
 
 	it('should use the requested timeout', async () => {
@@ -1124,8 +1200,69 @@ describe(`.run() method`, () => {
 
 		expect(result.status).to.equal('failed');
 		expect(result.failureSource).to.equal('target');
-		expect(result.rawOutput).to.equal('Request timeout.');
-		expect(result.timings.total).to.be.null;
+		expect(result.rawOutput).to.equal('Request timed out while waiting for the first response byte.');
+
+		expect(result.timings).to.deep.equal({
+			total: 5000,
+			download: null,
+			firstByte: null,
+			dns: 0,
+			tls: null,
+			tcp: 0,
+		});
+	});
+
+	it('should report a timeout during response download and preserve completed timings', async () => {
+		const fakeSocket = new Duplex({
+			read () {},
+			write (_chunk, _encoding, callback) {
+				callback();
+			},
+		});
+		(fakeSocket as any).remoteAddress = '93.184.216.34';
+
+		netConnectStub.callsFake(() => {
+			process.nextTick(() => {
+				fakeSocket.emit('lookup', null, '93.184.216.34', 4, 'google.com');
+				sandbox.clock.tick(10);
+				fakeSocket.emit('connect');
+				sandbox.clock.tick(15);
+				fakeSocket.push('HTTP/1.1 200 OK\r\nContent-Length: 10\r\n\r\npart');
+			});
+
+			return fakeSocket as any;
+		});
+
+		const promise = new HttpCommand().run(mockedSocket as any, 'measurement', 'test', {
+			type: 'http' as const,
+			timeout: 5,
+			target: 'google.com',
+			inProgressUpdates: false,
+			protocol: 'HTTP',
+			request: { method: 'GET', path: '/timeout', query: '' },
+			ipVersion: 4,
+		});
+
+		await new Promise(resolve => process.nextTick(resolve));
+		await new Promise(resolve => process.nextTick(resolve));
+		sandbox.clock.tick(5_001);
+
+		await promise;
+
+		const result = mockedSocket.emit.firstCall.args[1].result;
+
+		expect(result.status).to.equal('failed');
+		expect(result.failureSource).to.equal('target');
+		expect(result.rawOutput).to.equal('Request timed out while downloading the response.');
+
+		expect(result.timings).to.deep.equal({
+			total: 5000,
+			download: null,
+			firstByte: 15,
+			dns: 0,
+			tls: null,
+			tcp: 10,
+		});
 	});
 
 	it('should decompress gzip response', async () => {


### PR DESCRIPTION
Reports the active HTTP request phase on timeout and preserves timings for completed phases.