### PR TITLE
fix: handle fractional process timeouts

### DIFF
--- a/src/command/dns-command.ts
+++ b/src/command/dns-command.ts
@@ -182,6 +182,8 @@ export class DnsCommand implements CommandInterface<DnsOptions> {
 				output += `${output ? '\n\n' : ''}The measurement command timed out.`;
 			} else if (isExecaError(error) && error.stdout.toString().length > 0) {
 				output = this.rewrite(error.stdout.toString(), cmdOptions.trace);
+			} else if (isExecaError(error)) {
+				logger.error(error.shortMessage);
 			} else {
 				logger.error(error);
 			}

--- a/src/command/mtr-command.ts
+++ b/src/command/mtr-command.ts
@@ -180,7 +180,12 @@ export class MtrCommand implements CommandInterface<MtrOptions> {
 
 			if (isExecaError(error)) {
 				result.rawOutput = error.stdout.toString();
-				error.timedOut && (result.rawOutput += `${result.rawOutput ? '\n\n' : ''}The measurement command timed out.`);
+
+				if (error.timedOut) {
+					result.rawOutput += `${result.rawOutput ? '\n\n' : ''}The measurement command timed out.`;
+				} else {
+					logger.error(error.shortMessage);
+				}
 			} else {
 				cmd?.kill('SIGKILL');
 

--- a/src/command/ping-command.ts
+++ b/src/command/ping-command.ts
@@ -176,7 +176,8 @@ export class PingCommand implements CommandInterface<PingOptions> {
 			result = { status: 'failed', failureSource: 'internal', rawOutput: 'Test failed. Please try again.' };
 
 			if (isExecaError(error)) {
-				result = parse(error.stdout.toString());
+				const stdout = error.stdout.toString();
+				result = parse(stdout);
 
 				result.failureSource = classifyIcmpFailure(
 					error,
@@ -188,6 +189,8 @@ export class PingCommand implements CommandInterface<PingOptions> {
 				if (error.timedOut) {
 					result.status = 'failed';
 					result.rawOutput += `${result.rawOutput ? '\n\n' : ''}The measurement command timed out.`;
+				} else if (!stdout) {
+					logger.error(error.shortMessage);
 				}
 
 				!result.rawOutput && (result.rawOutput = 'Test failed. Please try again.');

--- a/src/command/traceroute-command.ts
+++ b/src/command/traceroute-command.ts
@@ -198,6 +198,8 @@ export class TracerouteCommand implements CommandInterface<TraceOptions> {
 					} catch {}
 
 					output += `${output ? '\n\n' : ''}The measurement command timed out.`;
+				} else if (!output) {
+					logger.error(error.shortMessage);
 				}
 			} else {
 				logger.error(error);

--- a/src/helper/timeout.ts
+++ b/src/helper/timeout.ts
@@ -88,5 +88,5 @@ export const getMtrBudget = (packets: number, remaining: number): MtrBudget => {
 };
 
 export const getProcessTimeout = (timeout: number, grace = processGrace): number => {
-	return (timeout + grace) * 1000;
+	return Math.round((timeout + grace) * 1000);
 };

--- a/test/unit/helper/timeout.test.ts
+++ b/test/unit/helper/timeout.test.ts
@@ -99,6 +99,13 @@ describe('command timeout helpers', () => {
 		expect(getProcessTimeout(5, 2)).to.equal(7000);
 	});
 
+	it('should return integer milliseconds for a fractional process timeout', () => {
+		const timeout = getProcessTimeout(14.999, 2);
+
+		expect(timeout).to.equal(16999);
+		expect(Number.isInteger(timeout)).to.equal(true);
+	});
+
 	it('should use the configured process grace by default', () => {
 		expect(getProcessTimeout(5)).to.equal(7000);
 	});


### PR DESCRIPTION
Rounds process timeouts to integer milliseconds to prevent immediate MTR failures caused by floating-point remaining budgets. Also logs unexpected native-command failures that produce no standard output.