### PR TITLE
fix: improve probe event acknowledgment handling

### DIFF
--- a/src/helper/alt-ips-client.ts
+++ b/src/helper/alt-ips-client.ts
@@ -80,6 +80,11 @@ export class AltIpsClient {
 		}
 
 		const response: unknown = await this.socket.volatile.emitWithAck('probe:alt-ips', ipsToTokens);
+
+		if (!response) {
+			throw new Error('The API failed to process the alternative IP update.');
+		}
+
 		const { addedAltIps, rejectedIpsToReasons } = response as { addedAltIps: string[]; rejectedIpsToReasons: Record<string, string> };
 
 		if (lifecycleId !== this.lifecycleId) {

--- a/src/helper/alt-ips-client.ts
+++ b/src/helper/alt-ips-client.ts
@@ -79,7 +79,7 @@ export class AltIpsClient {
 			return;
 		}
 
-		const response: unknown = await this.socket.volatile.timeout(60_000).emitWithAck('probe:alt-ips', ipsToTokens);
+		const response: unknown = await this.socket.volatile.emitWithAck('probe:alt-ips', ipsToTokens);
 		const { addedAltIps, rejectedIpsToReasons } = response as { addedAltIps: string[]; rejectedIpsToReasons: Record<string, string> };
 
 		if (lifecycleId !== this.lifecycleId) {

--- a/src/helper/alt-ips-client.ts
+++ b/src/helper/alt-ips-client.ts
@@ -79,39 +79,40 @@ export class AltIpsClient {
 			return;
 		}
 
-		this.socket.volatile.emit('probe:alt-ips', ipsToTokens, ({ addedAltIps, rejectedIpsToReasons }: { addedAltIps: string[]; rejectedIpsToReasons: Record<string, string> }) => {
-			if (lifecycleId !== this.lifecycleId) {
-				return;
-			}
+		const response: unknown = await this.socket.volatile.timeout(60_000).emitWithAck('probe:alt-ips', ipsToTokens);
+		const { addedAltIps, rejectedIpsToReasons } = response as { addedAltIps: string[]; rejectedIpsToReasons: Record<string, string> };
 
-			const uniqAcceptedIps = _.uniq([ this.ip, ...addedAltIps.sort() ]);
-			rejectedIps = { ...rejectedIps, ...rejectedIpsToReasons };
+		if (lifecycleId !== this.lifecycleId) {
+			return;
+		}
 
-			uniqAcceptedIps.forEach((ip) => {
-				delete rejectedIps[ip];
-				delete failedIps[ip];
-			});
+		const uniqAcceptedIps = _.uniq([ this.ip, ...addedAltIps.sort() ]);
+		rejectedIps = { ...rejectedIps, ...rejectedIpsToReasons };
 
-			const ipsChanged = !_.isEqual(uniqAcceptedIps, this.currentIps) || !_.isEqual(rejectedIps, this.currentRejectedIps) || !_.isEqual(failedIps, this.currentFailedIps);
-
-			this.currentIps = uniqAcceptedIps;
-			this.currentRejectedIps = rejectedIps;
-			this.currentFailedIps = failedIps;
-
-			if (ipsChanged) {
-				Object.entries(this.currentFailedIps).forEach(([ ip, error ]) => altIpsLogger.warn(`${error} (via ${ip}).`));
-				Object.entries(this.currentRejectedIps).forEach(([ ip, reason ]) => altIpsLogger.warn(`IP ${ip} rejected: ${reason}`));
-				mainLogger.info(`${pluralize('IP address', 'IP addresses', uniqAcceptedIps.length)} of the probe: ${uniqAcceptedIps.join(', ')}.`);
-			} else {
-				const groups = [
-					`Accepted: ${uniqAcceptedIps.join(', ')}.`,
-					Object.keys(rejectedIps).length ? `Rejected: ${Object.keys(rejectedIps).join(', ')}.` : '',
-					Object.keys(failedIps).length ? `Failed: ${Object.keys(failedIps).join(', ')}.` : '',
-				].filter(Boolean);
-
-				altIpsLogger.debug(`Alt IP status unchanged. ${groups.join(' ')}`);
-			}
+		uniqAcceptedIps.forEach((ip) => {
+			delete rejectedIps[ip];
+			delete failedIps[ip];
 		});
+
+		const ipsChanged = !_.isEqual(uniqAcceptedIps, this.currentIps) || !_.isEqual(rejectedIps, this.currentRejectedIps) || !_.isEqual(failedIps, this.currentFailedIps);
+
+		this.currentIps = uniqAcceptedIps;
+		this.currentRejectedIps = rejectedIps;
+		this.currentFailedIps = failedIps;
+
+		if (ipsChanged) {
+			Object.entries(this.currentFailedIps).forEach(([ ip, error ]) => altIpsLogger.warn(`${error} (via ${ip}).`));
+			Object.entries(this.currentRejectedIps).forEach(([ ip, reason ]) => altIpsLogger.warn(`IP ${ip} rejected: ${reason}`));
+			mainLogger.info(`${pluralize('IP address', 'IP addresses', uniqAcceptedIps.length)} of the probe: ${uniqAcceptedIps.join(', ')}.`);
+		} else {
+			const groups = [
+				`Accepted: ${uniqAcceptedIps.join(', ')}.`,
+				Object.keys(rejectedIps).length ? `Rejected: ${Object.keys(rejectedIps).join(', ')}.` : '',
+				Object.keys(failedIps).length ? `Failed: ${Object.keys(failedIps).join(', ')}.` : '',
+			].filter(Boolean);
+
+			altIpsLogger.debug(`Alt IP status unchanged. ${groups.join(' ')}`);
+		}
 	}
 
 	private async getAltIpToken (ip: string) {

--- a/src/lib/api-logs-transport.ts
+++ b/src/lib/api-logs-transport.ts
@@ -27,6 +27,7 @@ class ApiLogsTransport extends Transport {
 	private maxBufferSize: number;
 	private logBuffer: TransportInfo[] = [];
 	private droppedLogs: number = 0;
+	private hasLoggedDiscard = false;
 	private timer: NodeJS.Timeout | undefined = undefined;
 	private sendQueue: Promise<void> = Promise.resolve();
 
@@ -118,7 +119,7 @@ class ApiLogsTransport extends Transport {
 		try {
 			const response: unknown = await this.socket.emitWithAck('probe:logs', payload);
 
-			if (response === 'success') {
+			if (response === 'success' || response === 'discard') {
 				const droppedWhileAwaiting = this.droppedLogs - droppedInPayload;
 				const oldLogsRemaining = presentInPayload - droppedWhileAwaiting;
 
@@ -128,6 +129,13 @@ class ApiLogsTransport extends Transport {
 				} else {
 					this.droppedLogs = -oldLogsRemaining; // === droppedWhileAwaiting - presentInPayload
 				}
+			}
+
+			if (response === 'success') {
+				this.hasLoggedDiscard = false;
+			} else if (response === 'discard' && !this.hasLoggedDiscard) {
+				this.hasLoggedDiscard = true;
+				this.logger?.warn('The API discarded a log batch due to a schema validation failure.');
 			}
 		} catch (e) {
 			this.logger?.error('Failed to send logs to the API.', e);

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -118,27 +118,29 @@ function connect (workerId?: number) {
 
 		const closeTimeout = setTimeout(() => {
 			logger.warn(timeoutMessage);
-			void forceCloseProcess(true);
+			void closeProcess();
 		}, timeout);
 
 		const closeInterval = setInterval(() => {
 			if (worker.jobs.size === 0) {
 				clearTimeout(closeTimeout);
-				void forceCloseProcess();
+				void closeProcess();
 			}
 		}, 100);
 
-		const forceCloseProcess = async (force = false) => {
+		const closeProcess = async () => {
 			clearInterval(closeInterval);
 			clearInterval(worker.jobsInterval);
 
 			logger.debug('Exiting probe process.');
+			const forceExitTimeout = setTimeout(() => process.exit(0), 10_000);
 
-			if (!force) {
+			try {
 				await apiLogsTransport.flush();
+			} finally {
+				clearTimeout(forceExitTimeout);
+				process.exit(0);
 			}
-
-			process.exit(0);
 		};
 	};
 

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -177,12 +177,10 @@ function connect (workerId?: number) {
 			const { measurementId, testId, measurement } = data;
 
 			logger.debug(`${measurement.type} request ${measurementId} received.`);
-			worker.jobs.set(measurementId, Date.now());
 
 			const handler = handlersMap.get(measurement.type);
 
 			if (!handler) {
-				worker.jobs.delete(measurementId);
 				return;
 			}
 

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -165,7 +165,7 @@ function connect (workerId?: number) {
 		.on('api:connect:adoption', adoptionStatusHandler(socket))
 		.on('api:connect:ip', ipHandler(socket))
 		.on('api:settings:update', updateProbeSettings(socket))
-		.on('probe:measurement:request', (data: MeasurementRequest) => {
+		.on('probe:measurement:request', async (data: MeasurementRequest) => {
 			const status = statusManager.getStatus();
 
 			if (status !== 'ready') {
@@ -178,25 +178,23 @@ function connect (workerId?: number) {
 			logger.debug(`${measurement.type} request ${measurementId} received.`);
 			worker.jobs.set(measurementId, Date.now());
 
-			socket.emit('probe:measurement:ack', null, async () => {
-				const handler = handlersMap.get(measurement.type);
+			const handler = handlersMap.get(measurement.type);
 
-				if (!handler) {
-					worker.jobs.delete(measurementId);
-					return;
-				}
+			if (!handler) {
+				worker.jobs.delete(measurementId);
+				return;
+			}
 
-				worker.jobs.set(measurementId, Date.now());
+			worker.jobs.set(measurementId, Date.now());
 
-				try {
-					const out = await handler.run(socket, measurementId, testId, measurement);
-					logMeasurementResults && logger.silly(`${measurement.type} request ${measurementId} result: ${JSON.stringify(out)}`);
-				} catch (error: unknown) {
-					handleTestError(error, socket, measurementId, testId);
-				} finally {
-					worker.jobs.delete(measurementId);
-				}
-			});
+			try {
+				const out = await handler.run(socket, measurementId, testId, measurement);
+				logMeasurementResults && logger.silly(`${measurement.type} request ${measurementId} result: ${JSON.stringify(out)}`);
+			} catch (error: unknown) {
+				handleTestError(error, socket, measurementId, testId);
+			} finally {
+				worker.jobs.delete(measurementId);
+			}
 		})
 		.on('probe:adoption:code', logAdoptionCode)
 		.on('api:logs-transport:set', (data: ApiTransportSettings) => apiLogsTransport.updateSettings(data));

--- a/src/probe.ts
+++ b/src/probe.ts
@@ -88,6 +88,7 @@ function connect (workerId?: number) {
 
 	const socket = io(`${config.get<string>('api.host')}/probes`, {
 		transports: [ 'websocket' ],
+		ackTimeout: 60_000,
 		reconnectionDelay: 4000,
 		reconnectionDelayMax: 8000,
 		randomizationFactor: 0.5,

--- a/test/unit/helper/alt-ips-handler.test.ts
+++ b/test/unit/helper/alt-ips-handler.test.ts
@@ -116,17 +116,23 @@ describe('apiConnectAltIpsHandler', async () => {
 			});
 
 		const emit = sinon.stub();
-		const altIpsClient = new AltIpsClient({ volatile: { emit } } as unknown as Socket, '1.1.1.1');
+		const emitWithAck = sinon.stub().resolves({
+			addedAltIps: [ '2.2.2.2', '3.3.3.3', '44::44:44' ],
+			rejectedIpsToReasons: {},
+		});
+		const timeout = sinon.stub().returns({ emitWithAck });
+		const altIpsClient = new AltIpsClient({ volatile: { emit, timeout } } as unknown as Socket, '1.1.1.1');
 		await altIpsClient.refreshAltIps();
 
 		expect(reqs.length).to.equal(3);
 		expect(reqs[0].options.localAddress).to.equal('1.0.1.0');
 		expect(reqs[1].options.localAddress).to.equal('172.31.43.80');
 		expect(reqs[2].options.localAddress).to.equal('2a05:d016:174:7b28:f47b:e6:3307:fab6');
-		expect(emit.callCount).to.equal(1);
-		expect(emit.firstCall.args[0]).to.equal('probe:alt-ips');
+		expect(timeout.calledOnceWithExactly(60_000)).to.be.true;
+		expect(emitWithAck.callCount).to.equal(1);
+		expect(emitWithAck.firstCall.args[0]).to.equal('probe:alt-ips');
 
-		expect(emit.firstCall.args[1]).to.deep.equal([
+		expect(emitWithAck.firstCall.args[1]).to.deep.equal([
 			[ '2.2.2.2', 'token-2.2.2.2' ],
 			[ '3.3.3.3', 'token-3.3.3.3' ],
 			[ '44::44:44', 'token-44::44:44' ],

--- a/test/unit/helper/alt-ips-handler.test.ts
+++ b/test/unit/helper/alt-ips-handler.test.ts
@@ -138,4 +138,15 @@ describe('apiConnectAltIpsHandler', async () => {
 
 		expect(nock.isDone()).to.equal(true);
 	});
+
+	it('should reject an empty alt IP acknowledgment', async () => {
+		networkInterfaces.returns({});
+
+		const emitWithAck = sinon.stub().resolves(null);
+		const altIpsClient = new AltIpsClient({ volatile: { emitWithAck } } as unknown as Socket, '1.1.1.1');
+		const error = await altIpsClient.refreshAltIps().catch((error: unknown) => error);
+
+		expect(error).to.be.instanceof(Error);
+		expect((error as Error).message).to.equal('The API failed to process the alternative IP update.');
+	});
 });

--- a/test/unit/helper/alt-ips-handler.test.ts
+++ b/test/unit/helper/alt-ips-handler.test.ts
@@ -120,15 +120,13 @@ describe('apiConnectAltIpsHandler', async () => {
 			addedAltIps: [ '2.2.2.2', '3.3.3.3', '44::44:44' ],
 			rejectedIpsToReasons: {},
 		});
-		const timeout = sinon.stub().returns({ emitWithAck });
-		const altIpsClient = new AltIpsClient({ volatile: { emit, timeout } } as unknown as Socket, '1.1.1.1');
+		const altIpsClient = new AltIpsClient({ volatile: { emit, emitWithAck } } as unknown as Socket, '1.1.1.1');
 		await altIpsClient.refreshAltIps();
 
 		expect(reqs.length).to.equal(3);
 		expect(reqs[0].options.localAddress).to.equal('1.0.1.0');
 		expect(reqs[1].options.localAddress).to.equal('172.31.43.80');
 		expect(reqs[2].options.localAddress).to.equal('2a05:d016:174:7b28:f47b:e6:3307:fab6');
-		expect(timeout.calledOnceWithExactly(60_000)).to.be.true;
 		expect(emitWithAck.callCount).to.equal(1);
 		expect(emitWithAck.firstCall.args[0]).to.equal('probe:alt-ips');
 

--- a/test/unit/lib/api-logs-transport.test.ts
+++ b/test/unit/lib/api-logs-transport.test.ts
@@ -238,10 +238,10 @@ describe('ApiLogsTransport', () => {
 			expect(payload.skipped).to.equal(2);
 		});
 
-		it('should resend logs if emit ack fails until success', async () => {
+		it('should resend logs when the API requests a retry until success', async () => {
 			const { logger } = createTransportAndLogger({ isActive: true, sendInterval: 100, maxBufferSize: 2 });
 
-			setEmitWithAckResponse('error');
+			setEmitWithAckResponse('retry');
 
 			logger.info('test1');
 			logger.info('test2');
@@ -265,10 +265,10 @@ describe('ApiLogsTransport', () => {
 			expect(socket.emitWithAck.calledTwice).to.be.true;
 		});
 
-		it('should drop old logs when emit fails', async () => {
+		it('should drop old logs while the API requests retries', async () => {
 			const { logger } = createTransportAndLogger({ isActive: true, sendInterval: 100, maxBufferSize: 2 });
 
-			setEmitWithAckResponse('error');
+			setEmitWithAckResponse('retry');
 
 			logger.info('test1');
 			logger.info('test2');
@@ -294,6 +294,19 @@ describe('ApiLogsTransport', () => {
 			// no subsequent emits
 			await sandbox.clock.tickAsync(2000);
 			expect(socket.emitWithAck.calledThrice).to.be.true;
+		});
+
+		it('should discard logs when the API rejects them permanently', async () => {
+			const { logger } = createTransportAndLogger({ isActive: true, sendInterval: 100 });
+
+			setEmitWithAckResponse('discard');
+			logger.info('test');
+
+			await sandbox.clock.tickAsync(100 + ACK_DELAY);
+			expect(socket.emitWithAck.calledOnce).to.be.true;
+
+			await sandbox.clock.tickAsync(100 + ACK_DELAY);
+			expect(socket.emitWithAck.calledOnce).to.be.true;
 		});
 
 		it('should trim long messages', async () => {

--- a/test/unit/probe.test.ts
+++ b/test/unit/probe.test.ts
@@ -175,7 +175,7 @@ describe('index module', () => {
 		mockSocket.emit('probe:measurement:request', { measurementId: 'measurementid', testId: 'testid', measurement: { type: 'ping' } });
 
 		expect(PingCommandStub.calledOnce).to.be.true;
-		expect(handlers['probe:measurement:ack'].calledOnce).to.be.true;
+		expect(handlers['probe:measurement:ack'].notCalled).to.be.true;
 		expect(runIcmpStub.calledOnce).to.be.true;
 		expect(runIcmpStub.firstCall.args[0]).to.equal(pingCmdStub);
 		expect(runIcmpStub.firstCall.args[1]).to.equal(mockSocket);
@@ -275,33 +275,6 @@ describe('index module', () => {
 
 		expect(statusManagerStub.stop.callCount).to.equal(1);
 		expect(statusManagerStub.stop.args[0]).to.deep.equal([]);
-		expect(exitStub.calledOnce).to.be.true;
-	});
-
-	it('should wait for a measurement acknowledgment before exiting on SIGTERM', async () => {
-		const exitStub = sandbox.stub(process, 'exit');
-		let acknowledgeMeasurement: (() => void) | undefined;
-		await import('../../src/probe.js');
-
-		const measurementRequestHandler = mockSocket.listeners('probe:measurement:request').at(-1);
-		sandbox.stub(mockSocket, 'emit').callsFake((event: string, _data?: unknown, callback?: () => void) => {
-			if (event === 'probe:measurement:ack') {
-				acknowledgeMeasurement = callback;
-			}
-
-			return true;
-		});
-
-		measurementRequestHandler?.({ measurementId: '123', testId: 'test', measurement: { type: 'ping' } });
-		process.emit('SIGTERM');
-		await sandbox.clock.tickAsync(150);
-
-		expect(exitStub.notCalled).to.be.true;
-
-		acknowledgeMeasurement?.();
-		await sandbox.clock.tickAsync(100);
-
-		expect(runIcmpStub.calledOnce).to.be.true;
 		expect(exitStub.calledOnce).to.be.true;
 	});
 

--- a/test/unit/probe.test.ts
+++ b/test/unit/probe.test.ts
@@ -119,6 +119,7 @@ describe('index module', () => {
 
 		expect(ioStub.firstCall.args[1]).to.deep.include({
 			transports: [ 'websocket' ],
+			ackTimeout: 60_000,
 			reconnectionDelay: 4000,
 			reconnectionDelayMax: 8000,
 			randomizationFactor: 0.5,


### PR DESCRIPTION
- Guarantees shutdown exits after 10 seconds while still allowing a normal log flush.
- Adds explicit log outcomes and a 60-second timeout for acknowledged events.
- Removes the redundant measurement acknowledgment.