### PR TITLE
fix: reserve HTTP time after DNS lookup

### DIFF
--- a/src/command/handlers/http/undici.ts
+++ b/src/command/handlers/http/undici.ts
@@ -14,6 +14,7 @@ import type { FailureSource, TestStatus } from '../../../types.js';
 import { callbackify } from '../../../lib/util.js';
 import { isIpPrivate } from '../../../lib/ip.js';
 import { getErrorCode } from '../../../lib/error-code.js';
+import { createMeasurementDeadline, getHttpDnsTimeout } from '../../../helper/timeout.js';
 import { truncateHeaderPairs } from './truncate-headers.js';
 import { truncateToWellFormedString } from './truncate-string.js';
 
@@ -164,6 +165,7 @@ function getConnector (
 	result: Omit<Result, 'timings'>,
 	timings: Timings,
 	requestState: RequestState,
+	onDnsLookupComplete: () => void,
 ): buildConnector.connector {
 	return (connectorOptions, callback) => {
 		timings.start = Date.now();
@@ -178,6 +180,8 @@ function getConnector (
 		});
 
 		tcpSocket.on('lookup', (error, address) => {
+			onDnsLookupComplete();
+
 			if (error) {
 				// Handled in onError().
 				return;
@@ -312,6 +316,7 @@ export class HttpHandler {
 
 	private resolve!: (value: unknown) => void;
 	private timeoutTimer: NodeJS.Timeout | null = null;
+	private dnsTimeoutSignal: AbortSignal | null = null;
 	private decompressor: Decompressor | null = null;
 	private decompressorHasData = false;
 	private done = false;
@@ -329,18 +334,24 @@ export class HttpHandler {
 	public async run () {
 		const promise = new Promise((resolve) => { this.resolve = resolve; });
 		const server = this.options.resolver;
+		const targetIsHostname = isIP(this.options.target) === 0;
+		const deadline = createMeasurementDeadline(this.options.timeout);
+		this.dnsTimeoutSignal = targetIsHostname ? deadline.signalFor(getHttpDnsTimeout(this.options.timeout)) : null;
+		this.dnsTimeoutSignal?.addEventListener('abort', this.handleDnsTimeout, { once: true });
+
 		const dnsResolver = callbackify((hostname: string, options: { family: IpFamily }) => dnsLookup(hostname, {
 			family: options.family,
 			...(server ? { server } : {}),
+			...(this.dnsTimeoutSignal ? { signal: this.dnsTimeoutSignal } : {}),
 		}), true);
 		const allowH2 = this.options.protocol === 'HTTP2';
-		const requestState: RequestState = { phase: isIP(this.options.target) === 0 ? 'dns' : 'tcp' };
-		const connector = getConnector(this.options, this.port, this.isHttps, dnsResolver, this.result, this.timings, requestState);
+		const requestState: RequestState = { phase: targetIsHostname ? 'dns' : 'tcp' };
+		const connector = getConnector(this.options, this.port, this.isHttps, dnsResolver, this.result, this.timings, requestState, this.clearDnsTimeout);
 		this.undiciClient = new Client(this.url.origin, { connect: connector, allowH2 });
 
 		this.timeoutTimer = setTimeout(
 			() => this.handleError(timeoutMessages[requestState.phase], requestState.phase === 'dns' ? 'resolver' : 'target', true),
-			this.options.timeout * 1000,
+			deadline.remainingMs(),
 		);
 
 		this.undiciClient.dispatch({
@@ -506,9 +517,19 @@ export class HttpHandler {
 
 	private cleanup () {
 		clearTimeout(this.timeoutTimer!);
+		this.clearDnsTimeout();
 		this.decompressor?.destroy();
 		this.undiciClient.destroy().catch((error: Error) => console.error(error));
 	}
+
+	private clearDnsTimeout = () => {
+		this.dnsTimeoutSignal?.removeEventListener('abort', this.handleDnsTimeout);
+		this.dnsTimeoutSignal = null;
+	};
+
+	private handleDnsTimeout = () => {
+		this.handleError(new InternalError(timeoutMessages.dns, true, 'resolver'), 'resolver', true);
+	};
 
 	private handleSuccess = () => {
 		if (this.done) {

--- a/src/helper/timeout.ts
+++ b/src/helper/timeout.ts
@@ -27,6 +27,10 @@ const roundDown = (value: number, places = 2): number => {
 	return Math.floor((value + 1e-9) * scale) / scale;
 };
 
+export const getHttpDnsTimeout = (timeoutSeconds: number): number => {
+	return roundDown(Math.max(2, timeoutSeconds * 0.4));
+};
+
 export const getPingBudget = (packets: number, timeoutSeconds: number, intervalOverride?: number): PingBudget => {
 	const minimumDnsHeadroom = 1;
 	const minimumResponseTimeout = 1;

--- a/test/unit/command/http-command.test.ts
+++ b/test/unit/command/http-command.test.ts
@@ -379,6 +379,13 @@ describe(`.run() method`, () => {
 
 	beforeEach(() => {
 		sandbox = useSandboxWithFakeTimers({ useFakeTimers: { now: 0, shouldAdvanceTime: false } });
+
+		sandbox.stub(AbortSignal, 'timeout').callsFake((milliseconds) => {
+			const controller = new AbortController();
+			setTimeout(() => controller.abort(), milliseconds);
+			return controller.signal;
+		});
+
 		mockedSocket = sandbox.createStubInstance(Socket) as sinon.SinonStubbedInstance<Socket>;
 		netConnectStub = sandbox.stub(net, 'connect');
 	});
@@ -1028,7 +1035,7 @@ describe(`.run() method`, () => {
 		expect(result.rawOutput.length).to.equal(10_019); // 'HTTP/1.1 200' (12) + '\n' (1) + rawHeaders (10000) + '\n\n' (2) + 'body' (4)
 	});
 
-	it('should classify a timeout during DNS lookup as resolver', async () => {
+	it('should limit DNS lookup to 40% of the measurement timeout', async () => {
 		const fakeSocket = new Duplex({
 			read () {},
 			write (_chunk, _encoding, callback) {
@@ -1040,7 +1047,7 @@ describe(`.run() method`, () => {
 
 		const promise = new HttpCommand().run(mockedSocket as any, 'measurement', 'test', {
 			type: 'http' as const,
-			timeout: 5,
+			timeout: 15,
 			target: 'google.com',
 			inProgressUpdates: false,
 			protocol: 'HTTP',
@@ -1048,18 +1055,21 @@ describe(`.run() method`, () => {
 			ipVersion: 4,
 		});
 
-		sandbox.clock.tick(5_001);
+		sandbox.clock.tick(6_001);
+		const completedWithinDnsBudget = mockedSocket.emit.called;
+		sandbox.clock.tick(9_000);
 
 		await promise;
 
 		const result = mockedSocket.emit.firstCall.args[1].result;
 
+		expect(completedWithinDnsBudget).to.equal(true);
 		expect(result.status).to.equal('failed');
 		expect(result.failureSource).to.equal('resolver');
 		expect(result.rawOutput).to.equal('Request timed out during DNS lookup.');
 
 		expect(result.timings).to.deep.equal({
-			total: 5000,
+			total: 6000,
 			download: null,
 			firstByte: null,
 			dns: null,

--- a/test/unit/helper/timeout.test.ts
+++ b/test/unit/helper/timeout.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import {
 	createMeasurementDeadline,
+	getHttpDnsTimeout,
 	getMtrBudget,
 	getPingBudget,
 	getProcessTimeout,
@@ -54,6 +55,19 @@ describe('command timeout helpers', () => {
 				clock.restore();
 			}
 		});
+	});
+
+	describe('HTTP DNS timeout', () => {
+		for (const { timeout, expected } of [
+			{ timeout: 5, expected: 2 },
+			{ timeout: 10, expected: 4 },
+			{ timeout: 15, expected: 6 },
+			{ timeout: 30, expected: 12 },
+		]) {
+			it(`should reserve ${expected} seconds of a ${timeout}-second measurement`, () => {
+				expect(getHttpDnsTimeout(timeout)).to.equal(expected);
+			});
+		}
 	});
 
 	describe('ping budget', () => {


### PR DESCRIPTION
Caps HTTP target DNS resolution at 40% of the measurement timeout, with a two-second minimum, so slow DNS cannot consume the budget reserved for TCP, TLS, and the response. Keeps the overall deadline unchanged and reports DNS deadline expiry as a resolver failure.