### PR TITLE
fix: clarify DNS resolution timeout messages

### DIFF
--- a/src/command/handlers/http/undici.ts
+++ b/src/command/handlers/http/undici.ts
@@ -14,7 +14,7 @@ import type { FailureSource, TestStatus } from '../../../types.js';
 import { callbackify } from '../../../lib/util.js';
 import { isIpPrivate } from '../../../lib/ip.js';
 import { getErrorCode } from '../../../lib/error-code.js';
-import { createMeasurementDeadline, getHttpDnsTimeout } from '../../../helper/timeout.js';
+import { createMeasurementDeadline, getHttpDnsTimeout, MEASUREMENT_DNS_RESOLUTION_TIMEOUT_MESSAGE } from '../../../helper/timeout.js';
 import { truncateHeaderPairs } from './truncate-headers.js';
 import { truncateToWellFormedString } from './truncate-string.js';
 
@@ -88,7 +88,7 @@ type RequestState = { phase: RequestPhase };
 const lowerCaseKeys = (obj: Record<string, string>) => _.mapKeys(obj, (_value, key) => _.toLower(key)) as Record<string, string>;
 
 const timeoutMessages: Record<RequestPhase, string> = {
-	dns: 'Request timed out during DNS lookup.',
+	dns: MEASUREMENT_DNS_RESOLUTION_TIMEOUT_MESSAGE,
 	tcp: 'Request timed out while establishing the TCP connection.',
 	tls: 'Request timed out during the TLS handshake.',
 	firstByte: 'Request timed out while waiting for the first response byte.',
@@ -556,7 +556,6 @@ export class HttpHandler {
 			return;
 		}
 
-		const message = error instanceof Error ? error.message : error;
 		this.done = true;
 
 		if (preserveCompletedState) {
@@ -566,8 +565,13 @@ export class HttpHandler {
 		}
 
 		this.result.status = 'failed';
-		const codeFallback = isInternalHttpErrorCode(getErrorCode(error)) ? 'internal' : fallbackSource;
-		this.result.failureSource = getFailureSource(error, codeFallback);
+		const code = getErrorCode(error);
+		const codeFallback = isInternalHttpErrorCode(code) ? 'internal' : fallbackSource;
+		const failureSource = getFailureSource(error, codeFallback);
+		const message = code === 'ETIMEOUT' && failureSource === 'resolver'
+			? MEASUREMENT_DNS_RESOLUTION_TIMEOUT_MESSAGE
+			: error instanceof Error ? error.message : error;
+		this.result.failureSource = failureSource;
 		this.result.rawOutput = message;
 
 		if (preserveCompletedState && this.timings.start !== null) {

--- a/src/helper/resolve-command-target.ts
+++ b/src/helper/resolve-command-target.ts
@@ -1,7 +1,9 @@
 import { isIP } from 'node:net';
 import { cachedDnsLookupOne, type IpFamily, type LookupOptions, type RecordOptions } from '../lib/dns.js';
+import { getErrorCode } from '../lib/error-code.js';
 import { InternalError } from '../lib/internal-error.js';
 import { isIpPrivate, normalizeIp } from '../lib/ip.js';
+import { MEASUREMENT_DNS_RESOLUTION_TIMEOUT_MESSAGE } from './timeout.js';
 
 export type CommandTargetLookup = {
 	(hostname: string, options: LookupOptions): Promise<string>;
@@ -30,8 +32,8 @@ export const resolveCommandTarget = async (
 			const address = normalizeIp(await lookup(target, { family, signal }));
 			return { address, hostname: target };
 		} catch (error: unknown) {
-			if (signal.aborted) {
-				throw new InternalError('The measurement command timed out.', true, 'resolver');
+			if (signal.aborted || getErrorCode(error) === 'ETIMEOUT') {
+				throw new InternalError(MEASUREMENT_DNS_RESOLUTION_TIMEOUT_MESSAGE, true, 'resolver');
 			}
 
 			throw error;

--- a/src/helper/timeout.ts
+++ b/src/helper/timeout.ts
@@ -1,5 +1,7 @@
 import config from 'config';
 
+export const MEASUREMENT_DNS_RESOLUTION_TIMEOUT_MESSAGE = 'The measurement timed out during DNS resolution.';
+
 const processGrace = config.get<number>('commands.processGrace');
 const pingConfig = config.get<{ interval: number; minInterval: number }>('commands.ping');
 const mtrConfig = config.get<{ interval: number; minInterval: number }>('commands.mtr');

--- a/src/lib/dns.ts
+++ b/src/lib/dns.ts
@@ -6,6 +6,8 @@ import { InternalError } from './internal-error.js';
 
 export type IpFamily = 4 | 6;
 
+const DNS_RESOLUTION_TIMEOUT_MESSAGE = 'DNS resolution timed out.';
+
 export type LookupOptions = { family: IpFamily; server?: string; allowPrivate?: boolean; signal?: AbortSignal };
 export type RecordOptions = { rrtype: 'TXT' | 'PTR'; server?: string; signal?: AbortSignal };
 type Options = LookupOptions | RecordOptions;
@@ -77,7 +79,10 @@ const resolveRecords = async (hostname: string, options: Options): Promise<Resol
 				continue;
 			}
 
-			throw new InternalError((error as Error).message, true, isTargetFailure ? 'target' : 'resolver');
+			const message = code === 'ETIMEOUT' ? DNS_RESOLUTION_TIMEOUT_MESSAGE : (error as Error).message;
+			const internalError = new InternalError(message, true, isTargetFailure ? 'target' : 'resolver');
+
+			throw code === 'ETIMEOUT' ? Object.assign(internalError, { code }) : internalError;
 		}
 	}
 

--- a/test/unit/command/http-command.test.ts
+++ b/test/unit/command/http-command.test.ts
@@ -1066,7 +1066,7 @@ describe(`.run() method`, () => {
 		expect(completedWithinDnsBudget).to.equal(true);
 		expect(result.status).to.equal('failed');
 		expect(result.failureSource).to.equal('resolver');
-		expect(result.rawOutput).to.equal('Request timed out during DNS lookup.');
+		expect(result.rawOutput).to.equal('The measurement timed out during DNS resolution.');
 
 		expect(result.timings).to.deep.equal({
 			total: 6000,
@@ -1076,6 +1076,29 @@ describe(`.run() method`, () => {
 			tls: null,
 			tcp: null,
 		});
+	});
+
+	it('should format a resolver ETIMEOUT as a DNS resolution timeout', async () => {
+		const fakeSocket = new Duplex({ read () {}, write (_chunk, _encoding, callback) { callback(); } });
+		netConnectStub.callsFake(() => {
+			const error = Object.assign(new InternalError('DNS resolution timed out.', true, 'resolver'), { code: 'ETIMEOUT' });
+			process.nextTick(() => fakeSocket.emit('error', error));
+			return fakeSocket as any;
+		});
+
+		await new HttpCommand().run(mockedSocket as any, 'measurement', 'test', {
+			type: 'http',
+			timeout: 5,
+			target: 'example.com',
+			inProgressUpdates: false,
+			protocol: 'HTTP',
+			request: { method: 'GET', path: '/', query: '' },
+			ipVersion: 4,
+		});
+
+		const result = mockedSocket.emit.lastCall.args[1].result;
+		expect(result.failureSource).to.equal('resolver');
+		expect(result.rawOutput).to.equal('The measurement timed out during DNS resolution.');
 	});
 
 	it('should classify a timeout for an IP target as target', async () => {

--- a/test/unit/command/mtr-command.test.ts
+++ b/test/unit/command/mtr-command.test.ts
@@ -294,7 +294,7 @@ describe('mtr command executor', () => {
 			expect((mockedSocket.emit.firstCall.args[1] as any).result).to.include({
 				status: 'failed',
 				failureSource: 'resolver',
-				rawOutput: 'The measurement command timed out.',
+				rawOutput: 'The measurement timed out during DNS resolution.',
 			});
 		});
 

--- a/test/unit/command/ping-command.test.ts
+++ b/test/unit/command/ping-command.test.ts
@@ -315,7 +315,9 @@ describe('ping command executor', () => {
 				});
 
 				expect(cmd.notCalled).to.be.true;
-				expect((mockedSocket.emit.lastCall.args[1] as any).result.failureSource).to.equal('resolver');
+				const result = (mockedSocket.emit.lastCall.args[1] as any).result;
+				expect(result.failureSource).to.equal('resolver');
+				expect(result.rawOutput).to.equal('The measurement timed out during DNS resolution.');
 			});
 		}
 

--- a/test/unit/command/traceroute-command.test.ts
+++ b/test/unit/command/traceroute-command.test.ts
@@ -463,7 +463,9 @@ describe('trace command', () => {
 			});
 
 			expect(cmd.notCalled).to.be.true;
-			expect((mockSocket.emit.lastCall.args[1] as any).result.failureSource).to.equal('resolver');
+			const result = (mockSocket.emit.lastCall.args[1] as any).result;
+			expect(result.failureSource).to.equal('resolver');
+			expect(result.rawOutput).to.equal('The measurement timed out during DNS resolution.');
 		});
 
 		describe('mock', () => {

--- a/test/unit/helper/resolve-command-target.test.ts
+++ b/test/unit/helper/resolve-command-target.test.ts
@@ -52,7 +52,25 @@ describe('resolveCommandTarget', () => {
 			expect(error).to.be.instanceOf(InternalError);
 
 			expect(error).to.include({
-				message: 'The measurement command timed out.',
+				message: 'The measurement timed out during DNS resolution.',
+				failureSource: 'resolver',
+			});
+		}
+	});
+
+	it('formats a resolver timeout as a measurement timeout', async () => {
+		const signal = new AbortController().signal;
+		const lookupError = Object.assign(new InternalError('DNS resolution timed out.', true, 'resolver'), { code: 'ETIMEOUT' });
+		const lookup = sinon.stub().rejects(lookupError);
+
+		try {
+			await resolveCommandTarget('example.com', 4, signal, lookup);
+			expect.fail('Expected target resolution to fail.');
+		} catch (error: unknown) {
+			expect(error).to.be.instanceOf(InternalError);
+
+			expect(error).to.include({
+				message: 'The measurement timed out during DNS resolution.',
 				failureSource: 'resolver',
 			});
 		}

--- a/test/unit/lib/dns.test.ts
+++ b/test/unit/lib/dns.test.ts
@@ -3,6 +3,7 @@ import * as sinon from 'sinon';
 import dns from 'node:dns';
 import { performance } from 'node:perf_hooks';
 import { getDnsServers, dnsLookup, dnsLookupOne, cachedDnsLookup, cachedDnsLookupOne, clearDnsCache } from '../../../src/lib/dns.js';
+import { getErrorCode } from '../../../src/lib/error-code.js';
 import { getFailureSource } from '../../../src/lib/internal-error.js';
 import { callbackify } from '../../../src/lib/util.js';
 
@@ -235,19 +236,21 @@ describe('dnsLookup / cachedDnsLookup', () => {
 		expect(failureSource).to.equal('target');
 	});
 
-	it('classifies resolver failures as internal', async () => {
+	it('classifies and formats resolver timeouts', async () => {
 		const error = Object.assign(new Error('queryA ETIMEOUT example.com'), { code: 'ETIMEOUT' });
 		resolve4.rejects(error);
 
-		let failureSource;
+		let caughtError;
 
 		try {
 			await dnsLookup('example.com', { family: 4 });
-		} catch (error) {
-			failureSource = getFailureSource(error, 'target');
+		} catch (error: unknown) {
+			caughtError = error as Error;
 		}
 
-		expect(failureSource).to.equal('resolver');
+		expect(getFailureSource(caughtError, 'target')).to.equal('resolver');
+		expect(caughtError?.message).to.equal('DNS resolution timed out.');
+		expect(getErrorCode(caughtError)).to.equal('ETIMEOUT');
 	});
 
 	it('returns a private address when allowPrivate is set', async () => {


### PR DESCRIPTION
Distinguishes measurement deadlines reached during hostname resolution from subprocess timeouts.